### PR TITLE
All LVM volumes must deactivate as part of unmount

### DIFF
--- a/mount-daemon/controllers/clientmount_controller.go
+++ b/mount-daemon/controllers/clientmount_controller.go
@@ -181,11 +181,11 @@ func (r *ClientMountReconciler) unmount(ctx context.Context, clientMountInfo dws
 
 	if clientMountInfo.Device.Type == dwsv1alpha1.ClientMountDeviceTypeLVM {
 
-		if clientMountInfo.Type == "gfs2" {
-			if _, err := r.run(fmt.Sprintf("vgchange --activate n %s", clientMountInfo.Device.LVM.VolumeGroup)); err != nil {
-				return err
-			}
+		if _, err := r.run(fmt.Sprintf("vgchange --activate n %s", clientMountInfo.Device.LVM.VolumeGroup)); err != nil {
+			return err
+		}
 
+		if clientMountInfo.Type == "gfs2" {
 			if _, err := r.run(fmt.Sprintf("vgchange --lockstop %s", clientMountInfo.Device.LVM.VolumeGroup)); err != nil {
 				return err
 			}


### PR DESCRIPTION
Failure to deactivate will leave behind a `/dev/mapper/` object. Any reuse of the vg/lv names and the activation will fail

```
$ vgchange --activate y default-nnf08-xfs-0-xfs-0-0_vg
device-mapper: create ioctl on default--nnf08--xfs--0--xfs--0--0_vg-default--nnf08--xfs--0--xfs--0--0_lv LVM-XHV5nm5PfYiZ5YIw09KgZCV38uCyMAnEEEpLHsl78Dox2C1oSjYGPZKsPoiFSuSq failed: Device or resource busy
```

Performing the deactivate fixes this issue

Signed-off-by: Nate Roiger <nate.roiger@hpe.com>