### PR TITLE
RABSW-986 DWS-Storages: Capacity should always be set even when 0

### DIFF
--- a/api/v1alpha1/storage_types.go
+++ b/api/v1alpha1/storage_types.go
@@ -92,7 +92,7 @@ type StorageData struct {
 	// Capacity is the number of bytes this storage provides. This is the
 	// total accessible bytes as determined by the driver and may be different
 	// than the sum of the devices' capacities.
-	Capacity int64 `json:"capacity,omitempty"`
+	Capacity int64 `json:"capacity"`
 
 	// Status is the overall status of the storage
 	// +kubebuilder:validation:Enum=Starting;Ready;Disabled;NotPresent;Offline;Failed

--- a/config/crd/bases/dws.cray.hpe.com_storages.yaml
+++ b/config/crd/bases/dws.cray.hpe.com_storages.yaml
@@ -138,6 +138,8 @@ spec:
                 enum:
                 - NVMe
                 type: string
+            required:
+            - capacity
             type: object
           kind:
             description: 'Kind is a string value representing the REST resource this


### PR DESCRIPTION
In the case when a rabbit is missing all of its drives, the Capacity will be 0. Provide 0 in this case as a courtesy for consumers of the Storages Resource.