### PR TITLE
Ignore the clientmount daemon executable in .gitignore/.dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 # Ignore build and test binaries.
 bin/
 testbin/
+mount-daemon/clientmount

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ commands.log
 kind-*.yaml
 
 nnf-sos
+mount-daemon/clientmount
+


### PR DESCRIPTION
Ignore the clientmount daemon executable, so it isn't accidently scooped up with a git-add.

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>