### PR TITLE
RABSW-986 DWS-Storages: Capacity should always be set even when 0

### DIFF
--- a/api/v1alpha1/storage_types.go
+++ b/api/v1alpha1/storage_types.go
@@ -92,6 +92,7 @@ type StorageData struct {
 	// Capacity is the number of bytes this storage provides. This is the
 	// total accessible bytes as determined by the driver and may be different
 	// than the sum of the devices' capacities.
+	// +kubebuilder:default:=0
 	Capacity int64 `json:"capacity"`
 
 	// Status is the overall status of the storage

--- a/config/crd/bases/dws.cray.hpe.com_storages.yaml
+++ b/config/crd/bases/dws.cray.hpe.com_storages.yaml
@@ -84,6 +84,7 @@ spec:
                     type: array
                 type: object
               capacity:
+                default: 0
                 description: Capacity is the number of bytes this storage provides.
                   This is the total accessible bytes as determined by the driver and
                   may be different than the sum of the devices' capacities.


### PR DESCRIPTION
Set a default value for capacity, to avoid error:
"error": "Storage.dws.cray.hpe.com \"rabbit-dev-01\" is invalid: data.capacity: Required value"

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>