### PR TITLE
RABSW-996: Handle multiple #DW errors properly

### DIFF
--- a/controllers/workflow_controller.go
+++ b/controllers/workflow_controller.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -60,19 +61,20 @@ type WorkflowReconciler struct {
 
 // checkDriverStatus returns true if all registered drivers for the current state completed successfully
 func checkDriverStatus(instance *dwsv1alpha1.Workflow) (bool, error) {
+	completed := ConditionTrue
+
 	for _, d := range instance.Status.Drivers {
 		if d.WatchState == instance.Status.State {
 			if strings.ToLower(d.Reason) == "error" {
 				// Return errors
-				return ConditionTrue, myerror.New(d.Message)
+				return ConditionFalse, myerror.New(d.Message)
 			}
 			if d.Completed == ConditionFalse {
-				// Return not ready
-				return ConditionFalse, nil
+				completed = ConditionFalse
 			}
 		}
 	}
-	return ConditionTrue, nil
+	return completed, nil
 }
 
 //+kubebuilder:rbac:groups=dws.cray.hpe.com,resources=workflows,verbs=get;list;watch;update;patch
@@ -100,6 +102,14 @@ func (r *WorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+
+	statusUpdater := newWorkflowStatusUpdater(workflow)
+	defer func() {
+		updateErr := statusUpdater.close(ctx, r)
+		if err == nil && updateErr != nil {
+			err = updateErr
+		}
+	}()
 
 	// Check if the object is being deleted
 	if !workflow.GetDeletionTimestamp().IsZero() {
@@ -145,7 +155,7 @@ func (r *WorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		log.Info("Workflow state transitioning to " + workflow.Spec.DesiredState)
 		workflow.Status.State = workflow.Spec.DesiredState
 		workflow.Status.Ready = ConditionFalse
-		workflow.Status.Reason = ""
+		workflow.Status.Reason = "DriverWait"
 		workflow.Status.Message = ""
 		ts := metav1.NowMicro()
 		workflow.Status.DesiredStateChange = &ts
@@ -184,33 +194,25 @@ func (r *WorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 	}
 
-	updateNeeded := false
 	driverDone, err := checkDriverStatus(workflow)
 	if err != nil {
-		// Update Status only if not already in an ERROR state
-		if workflow.Status.State != workflow.Spec.DesiredState ||
-			workflow.Status.Ready != ConditionFalse ||
-			workflow.Status.Reason != "ERROR" {
+		if workflow.Status.Reason != "ERROR" {
 			log.Info("Workflow state transitioning to " + "ERROR")
-			workflow.Status.State = workflow.Spec.DesiredState
-			workflow.Status.Ready = ConditionFalse
-			workflow.Status.Reason = "ERROR"
-			workflow.Status.Message = err.Error()
-			updateNeeded = true
 		}
+
+		workflow.Status.Reason = "ERROR"
+		workflow.Status.Message = err.Error()
 	} else {
 		// Set Ready/Reason based on driverDone condition
 		// All drivers achieving the current desiredStatus means we've achieved the desired state
 		if driverDone == ConditionTrue {
 			if workflow.Status.Ready != ConditionTrue {
-				workflow.Status.Ready = ConditionTrue
 				ts := metav1.NowMicro()
 				workflow.Status.ReadyChange = &ts
 				workflow.Status.ElapsedTimeLastState = ts.Time.Sub(workflow.Status.DesiredStateChange.Time).Round(time.Microsecond).String()
 				workflow.Status.Reason = "Completed"
 				workflow.Status.Message = "Workflow " + workflow.Status.State + " completed successfully"
 				log.Info("Workflow transitioning to ready state " + workflow.Status.State)
-				updateNeeded = true
 			}
 		} else {
 			// Driver not ready, update Status if not already in DriverWait
@@ -219,18 +221,11 @@ func (r *WorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				workflow.Status.Reason = "DriverWait"
 				workflow.Status.Message = "Workflow " + workflow.Status.State + " waiting for driver completion"
 				log.Info("Workflow state=" + workflow.Status.State + " waiting for driver completion")
-				updateNeeded = true
 			}
 		}
 	}
-	if updateNeeded {
-		err = r.Update(ctx, workflow)
-		if err != nil {
-			log.Error(err, "Failed to update Workflow state")
-			return ctrl.Result{}, nil
-		}
-		log.Info("Status was updated", "State", workflow.Status.State)
-	}
+
+	workflow.Status.Ready = driverDone
 
 	return ctrl.Result{}, nil
 }
@@ -266,6 +261,29 @@ func (r *WorkflowReconciler) createComputes(ctx context.Context, wf *dwsv1alpha1
 	}
 
 	return computes, nil
+}
+
+type workflowStatusUpdater struct {
+	workflow       *dwsv1alpha1.Workflow
+	existingStatus dwsv1alpha1.WorkflowStatus
+}
+
+func newWorkflowStatusUpdater(w *dwsv1alpha1.Workflow) *workflowStatusUpdater {
+	return &workflowStatusUpdater{
+		workflow:       w,
+		existingStatus: (*w.DeepCopy()).Status,
+	}
+}
+
+func (w *workflowStatusUpdater) close(ctx context.Context, r *WorkflowReconciler) error {
+	if !reflect.DeepEqual(w.workflow.Status, w.existingStatus) {
+		err := r.Update(ctx, w.workflow)
+		if !apierrors.IsConflict(err) {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
This commit improves how the DWS workflow controller handles multiple #DWs
that have registered for the same workflow phases. If any of the driverStatus
elements for the current phase have an error, then one of the errors is reported
in the workflow status. If that error is resolved, then the workflow status shows
any other errors fom other driverStatus elements. Once there are no errors, then
the workflow status no longer shows an error.

Signed-off-by: Matt Richerson <mattr@cray.com>