### PR TITLE
RABSW-997 Change Workflow.Status.Reason to .Status.Status and add to …

### DIFF
--- a/api/v1alpha1/workflow_types.go
+++ b/api/v1alpha1/workflow_types.go
@@ -128,7 +128,8 @@ type WorkflowStatus struct {
 	Ready bool `json:"ready"`
 
 	// User readable reason and status message
-	Reason  string `json:"reason,omitempty"`
+	// +kubebuilder:validation:Enum=Completed;DriverWait;Error
+	Status  string `json:"status,omitempty"`
 	Message string `json:"message,omitempty"`
 
 	// Set of DW environment variable settings for WLM to apply to the job.
@@ -160,11 +161,12 @@ type WorkflowStatus struct {
 }
 
 //+kubebuilder:object:root=true
-//+kubebuilder:printcolumn:name="DESIREDSTATE",type="string",JSONPath=".spec.desiredState",description="Desired state"
 //+kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.state",description="Current state"
 //+kubebuilder:printcolumn:name="READY",type="boolean",JSONPath=".status.ready",description="True if current state is achieved"
+//+kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.status",description="Indicates achievement of current state"
 //+kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 //+kubebuilder:printcolumn:name="JOBID",type="integer",JSONPath=".spec.jobID",description="Job ID",priority=1
+//+kubebuilder:printcolumn:name="DESIREDSTATE",type="string",JSONPath=".spec.desiredState",description="Desired state",priority=1
 //+kubebuilder:printcolumn:name="DESIREDSTATECHANGE",type="date",JSONPath=".status.desiredStateChange",description="Time of most recent desiredState change",priority=1
 //+kubebuilder:printcolumn:name="ELAPSEDTIMELASTSTATE",type="string",JSONPath=".status.elapsedTimeLastState",description="Duration of last state change",priority=1
 

--- a/config/crd/bases/dws.cray.hpe.com_workflows.yaml
+++ b/config/crd/bases/dws.cray.hpe.com_workflows.yaml
@@ -17,10 +17,6 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: Desired state
-      jsonPath: .spec.desiredState
-      name: DESIREDSTATE
-      type: string
     - description: Current state
       jsonPath: .status.state
       name: STATE
@@ -29,6 +25,10 @@ spec:
       jsonPath: .status.ready
       name: READY
       type: boolean
+    - description: Indicates achievement of current state
+      jsonPath: .status.status
+      name: STATUS
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date
@@ -37,6 +37,11 @@ spec:
       name: JOBID
       priority: 1
       type: integer
+    - description: Desired state
+      jsonPath: .spec.desiredState
+      name: DESIREDSTATE
+      priority: 1
+      type: string
     - description: Time of most recent desiredState change
       jsonPath: .status.desiredStateChange
       name: DESIREDSTATECHANGE
@@ -281,13 +286,17 @@ spec:
                   status
                 format: date-time
                 type: string
-              reason:
-                description: User readable reason and status message
-                type: string
               state:
                 default: proposal
                 description: The state the resource is currently transitioning to.
                   Updated by the controller once started.
+                type: string
+              status:
+                description: User readable reason and status message
+                enum:
+                - Completed
+                - DriverWait
+                - Error
                 type: string
             required:
             - ready


### PR DESCRIPTION
…Printcols

Rename the Workflow.Status.Reason to .Status.Status.  Make it a
kubebuilder:Enum, and add it to printcols.

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>