### PR TITLE
RABSW-999: Add error field to driver status

### DIFF
--- a/api/v1alpha1/workflow_types.go
+++ b/api/v1alpha1/workflow_types.go
@@ -112,6 +112,10 @@ type WorkflowDriverStatus struct {
 	Reason  string `json:"reason,omitempty"`
 	Message string `json:"message,omitempty"`
 
+	// Driver error string. This is not rolled up into the workflow's
+	// overall status section
+	Error string `json:"error,omitempty"`
+
 	// CompleteTime reflects the time that the workflow reconciler marks the driver complete
 	CompleteTime *metav1.MicroTime `json:"completeTime,omitempty"`
 }

--- a/config/crd/bases/dws.cray.hpe.com_workflows.yaml
+++ b/config/crd/bases/dws.cray.hpe.com_workflows.yaml
@@ -242,6 +242,10 @@ spec:
                       type: string
                     dwdIndex:
                       type: integer
+                    error:
+                      description: Driver error string. This is not rolled up into
+                        the workflow's overall status section
+                      type: string
                     lastHB:
                       format: int64
                       type: integer


### PR DESCRIPTION
This commit adds and error field to the entries in thedriverstatus array.
The error field is meant to provide a non-user facing error message when
something goes wrong. This field is not meant to be rolled up into the overall
status of the workflow, and it is not parsed by the WLM. This field is intended
to be used by admins and developers.

Signed-off-by: Matt Richerson <mattr@cray.com>