### PR TITLE
RABSW-999: Change driver status aggregation

### DIFF
--- a/api/v1alpha1/workflow_types.go
+++ b/api/v1alpha1/workflow_types.go
@@ -58,6 +58,15 @@ var workflowStrings = [...]string{
 	"teardown",
 }
 
+const (
+	StatusPending    = "Pending"
+	StatusQueued     = "Queued"
+	StatusRunning    = "Running"
+	StatusCompleted  = "Completed"
+	StatusError      = "Error"
+	StatusDriverWait = "DriverWait"
+)
+
 func (s WorkflowState) String() string {
 	return workflowStrings[s]
 }
@@ -109,7 +118,9 @@ type WorkflowDriverStatus struct {
 	// User readable reason.
 	// For the CDS driver, this could be the state of the underlying
 	// data movement request:  Pending, Queued, Running, Completed or Error
-	Reason  string `json:"reason,omitempty"`
+	// +kubebuilder:validation:Enum=Pending;Queued;Running;Completed;Error
+	Status string `json:"status,omitempty"`
+
 	Message string `json:"message,omitempty"`
 
 	// Driver error string. This is not rolled up into the workflow's

--- a/config/crd/bases/dws.cray.hpe.com_workflows.yaml
+++ b/config/crd/bases/dws.cray.hpe.com_workflows.yaml
@@ -251,10 +251,16 @@ spec:
                       type: integer
                     message:
                       type: string
-                    reason:
+                    status:
                       description: 'User readable reason. For the CDS driver, this
                         could be the state of the underlying data movement request:  Pending,
                         Queued, Running, Completed or Error'
+                      enum:
+                      - Pending
+                      - Queued
+                      - Running
+                      - Completed
+                      - Error
                       type: string
                     taskID:
                       type: string

--- a/controllers/workflow_controller.go
+++ b/controllers/workflow_controller.go
@@ -21,7 +21,6 @@ package controllers
 
 import (
 	"context"
-	myerror "errors"
 	"reflect"
 	"runtime"
 	"strings"
@@ -57,24 +56,6 @@ type WorkflowReconciler struct {
 	Scheme       *kruntime.Scheme
 	Log          logr.Logger
 	ChildObjects []dwsv1alpha1.ObjectList
-}
-
-// checkDriverStatus returns true if all registered drivers for the current state completed successfully
-func checkDriverStatus(instance *dwsv1alpha1.Workflow) (bool, error) {
-	completed := ConditionTrue
-
-	for _, d := range instance.Status.Drivers {
-		if d.WatchState == instance.Status.State {
-			if strings.ToLower(d.Reason) == "error" {
-				// Return errors
-				return ConditionFalse, myerror.New(d.Message)
-			}
-			if d.Completed == ConditionFalse {
-				completed = ConditionFalse
-			}
-		}
-	}
-	return completed, nil
 }
 
 //+kubebuilder:rbac:groups=dws.cray.hpe.com,resources=workflows,verbs=get;list;watch;update;patch
@@ -186,37 +167,45 @@ func (r *WorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		}
 	}
 
-	driverDone, err := checkDriverStatus(workflow)
-	if err != nil {
-		if workflow.Status.Status != "Error" {
-			log.Info("Workflow state transitioning to Error")
+	// If the workflow has already been marked as complete for this state, then
+	// we don't need to check the drivers. The drivers can't transition from complete
+	// to not complete
+	if workflow.Status.Ready == true {
+		return ctrl.Result{}, nil
+	}
+
+	workflow.Status.Ready = true
+	workflow.Status.Status = "Completed"
+	workflow.Status.Message = ""
+
+	// Loop through the driver status array and update the workflow
+	// status as necessary
+	for _, driver := range workflow.Status.Drivers {
+		if driver.WatchState != workflow.Status.State {
+			continue
 		}
 
-		workflow.Status.Status = "Error"
-		workflow.Status.Message = err.Error()
-	} else {
-		// Set Ready/Status based on driverDone condition
-		// All drivers achieving the current desiredStatus means we've achieved the desired state
-		if driverDone == ConditionTrue {
-			if workflow.Status.Ready != ConditionTrue {
-				ts := metav1.NowMicro()
-				workflow.Status.ReadyChange = &ts
-				workflow.Status.ElapsedTimeLastState = ts.Time.Sub(workflow.Status.DesiredStateChange.Time).Round(time.Microsecond).String()
-				workflow.Status.Status = "Completed"
-				workflow.Status.Message = "Workflow " + workflow.Status.State + " completed successfully"
-				log.Info("Workflow transitioning to ready state " + workflow.Status.State)
-			}
-		} else {
-			// Driver not ready, update Status if not already in DriverWait
-			if workflow.Status.Status != "DriverWait" {
-				workflow.Status.Status = "DriverWait"
-				workflow.Status.Message = "Workflow " + workflow.Status.State + " waiting for driver completion"
-				log.Info("Workflow state=" + workflow.Status.State + " waiting for driver completion")
-			}
+		if driver.Completed == false {
+			workflow.Status.Ready = false
+			workflow.Status.Status = "DriverWait"
+		}
+
+		if driver.Message != "" {
+			workflow.Status.Message = driver.Message
+		}
+
+		if strings.ToLower(driver.Reason) == "error" {
+			workflow.Status.Status = "Error"
+			break
 		}
 	}
 
-	workflow.Status.Ready = driverDone
+	if workflow.Status.Ready == true {
+		ts := metav1.NowMicro()
+		workflow.Status.ReadyChange = &ts
+		workflow.Status.ElapsedTimeLastState = ts.Time.Sub(workflow.Status.DesiredStateChange.Time).Round(time.Microsecond).String()
+		log.Info("Workflow transitioning to ready state " + workflow.Status.State)
+	}
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/workflow_controller.go
+++ b/controllers/workflow_controller.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"reflect"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -134,7 +133,7 @@ func (r *WorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		log.Info("Workflow state transitioning to " + workflow.Spec.DesiredState)
 		workflow.Status.State = workflow.Spec.DesiredState
 		workflow.Status.Ready = ConditionFalse
-		workflow.Status.Status = "DriverWait"
+		workflow.Status.Status = dwsv1alpha1.StatusDriverWait
 		workflow.Status.Message = ""
 		ts := metav1.NowMicro()
 		workflow.Status.DesiredStateChange = &ts
@@ -175,7 +174,7 @@ func (r *WorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 	}
 
 	workflow.Status.Ready = true
-	workflow.Status.Status = "Completed"
+	workflow.Status.Status = dwsv1alpha1.StatusCompleted
 	workflow.Status.Message = ""
 
 	// Loop through the driver status array and update the workflow
@@ -187,15 +186,15 @@ func (r *WorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 
 		if driver.Completed == false {
 			workflow.Status.Ready = false
-			workflow.Status.Status = "DriverWait"
+			workflow.Status.Status = dwsv1alpha1.StatusDriverWait
 		}
 
 		if driver.Message != "" {
 			workflow.Status.Message = driver.Message
 		}
 
-		if strings.ToLower(driver.Reason) == "error" {
-			workflow.Status.Status = "Error"
+		if driver.Status == dwsv1alpha1.StatusError {
+			workflow.Status.Status = dwsv1alpha1.StatusError
 			break
 		}
 	}


### PR DESCRIPTION
This commit changes the driver status aggregation to allow using the message field
from a driver entry when the driver hasn't indicated an error. This is used to provide
a human readable string for an error that may be recoverable.

Signed-off-by: Matt Richerson <mattr@cray.com>