### PR TITLE
RABSW-1007: Check for unique fields

### DIFF
--- a/api/v1alpha1/workflow_webhook.go
+++ b/api/v1alpha1/workflow_webhook.go
@@ -209,13 +209,15 @@ func checkDirectives(workflow *Workflow, ruleParser RuleParser) error {
 		return err
 	}
 
+	uniqueMap := make(map[string]bool)
+
 	for i, directive := range workflow.Spec.DWDirectives {
 		validDirective := false
 		for _, rule := range ruleParser.GetRuleList() {
 			// validate #DW syntax
 			const rejectUnsupportedCommands bool = true
 
-			valid, err := dwdparse.ValidateDWDirective(rule, directive, rejectUnsupportedCommands)
+			valid, err := dwdparse.ValidateDWDirective(rule, directive, uniqueMap, rejectUnsupportedCommands)
 			if err != nil {
 				// #DW parser validation failed
 				workflowlog.Info("dwDirective validation failed", "Error", err)

--- a/config/crd/bases/dws.cray.hpe.com_dwdirectiverules.yaml
+++ b/config/crd/bases/dws.cray.hpe.com_dwdirectiverules.yaml
@@ -64,6 +64,8 @@ spec:
                         type: string
                       type:
                         type: string
+                      uniqueWithin:
+                        type: string
                     required:
                     - key
                     - type

--- a/utils/dwdparse/dwdparse_test.go
+++ b/utils/dwdparse/dwdparse_test.go
@@ -48,6 +48,7 @@ var dWDRules = []DWDirectiveRuleSpec{
 				Pattern:         "^([A-Za-z0-9_-]+)$",
 				IsRequired:      true,
 				IsValueRequired: true,
+				UniqueWithin:    "jobdw_name",
 			},
 			{
 				Key:             "profile",
@@ -94,6 +95,7 @@ var dWDRules = []DWDirectiveRuleSpec{
 				Pattern:         "^([A-Za-z0-9_-]+)$",
 				IsRequired:      true,
 				IsValueRequired: true,
+				UniqueWithin:    "create_persistent_name",
 			},
 			{
 				Key:             "profile",
@@ -186,6 +188,7 @@ var dWDRules = []DWDirectiveRuleSpec{
 				Pattern:         "^([A-Za-z0-9_-]+)$",
 				IsRequired:      true,
 				IsValueRequired: true,
+				UniqueWithin:    "destroy_persistent_name",
 			},
 		},
 	},
@@ -238,174 +241,187 @@ const (
 )
 
 var dwDirectiveTests = []struct {
-	directive          string // #DW directive
-	failUnknownCommand bool   // deny/allow unknown commands
-	validCommand       bool   // expected parse error result compared with nil
+	directiveList      []string // #DW directive
+	failUnknownCommand bool     // deny/allow unknown commands
+	validCommand       bool     // expected parse error result compared with nil
 }{
-	{"#DW jobdw type=raw    capacity=100GB name=prettyGoodName  ", deny, validDWOrAllowUnknownCommand},
-	{"#DW jobdw type=xfs    capacity=100GB name=pretty_GoodName ", deny, validDWOrAllowUnknownCommand},
-	{"#DW jobdw type=gfs2   capacity=100GB name=pretty_GoodName ", deny, validDWOrAllowUnknownCommand},
-	{"#DW jobdw type=lustre capacity=100GB name=prettyGood-Name ", deny, validDWOrAllowUnknownCommand},
-	{"#DW jobdw type=raw    capacity=100TB name=__prettyGoodName", deny, validDWOrAllowUnknownCommand},
-	{"#DW jobdw type=xfs    capacity=100TB name=-prettyGoodName-", deny, validDWOrAllowUnknownCommand},
-	{"#DW jobdw type=lustre capacity=100TB name=0prettyGoodName1", deny, validDWOrAllowUnknownCommand},
-	{"#DW jobdw type=raw    capacity=100GB name=prettierGoodName", deny, validDWOrAllowUnknownCommand},
-	{"#DW jobdw type=xfs    capacity=100GB name=prettierGoodName", deny, validDWOrAllowUnknownCommand},
-	{"#DW jobdw type=lustre capacity=100GB name=prettierGoodName", deny, validDWOrAllowUnknownCommand},
-	{"#DW jobdw type=lustre capacity=100GB name=prettierGoodName", deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=raw    capacity=100GB name=prettyGoodName  "}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=xfs    capacity=100GB name=pretty_GoodName "}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=gfs2   capacity=100GB name=pretty_GoodName "}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=lustre capacity=100GB name=prettyGood-Name "}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=raw    capacity=100TB name=__prettyGoodName"}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=xfs    capacity=100TB name=-prettyGoodName-"}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=lustre capacity=100TB name=0prettyGoodName1"}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=raw    capacity=100GB name=prettierGoodName"}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=xfs    capacity=100GB name=prettierGoodName"}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=lustre capacity=100GB name=prettierGoodName"}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=lustre capacity=100GB name=prettierGoodName"}, deny, validDWOrAllowUnknownCommand},
 
-	{"#DW jobdw type=raw    capacity=100GB name=prettyGoodName  ", allow, validDWOrAllowUnknownCommand},
-	{"#DW jobdw type=xfs    capacity=100GB name=prettyGoodName  ", allow, validDWOrAllowUnknownCommand},
-	{"#DW jobdw type=lustre capacity=100GB name=prettyGoodName  ", allow, validDWOrAllowUnknownCommand},
-	{"#DW jobdw type=raw    capacity=100TB name=prettyGoodName  ", allow, validDWOrAllowUnknownCommand},
-	{"#DW jobdw type=xfs    capacity=100TB name=prettyGoodName  ", allow, validDWOrAllowUnknownCommand},
-	{"#DW jobdw type=lustre capacity=100TB name=prettyGoodName  ", allow, validDWOrAllowUnknownCommand},
-	{"#DW jobdw type=raw    capacity=100GB name=prettierGoodName", allow, validDWOrAllowUnknownCommand},
-	{"#DW jobdw type=xfs    capacity=100GB name=prettierGoodName", allow, validDWOrAllowUnknownCommand},
-	{"#DW jobdw type=lustre capacity=100GB name=prettierGoodName", allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=raw    capacity=100GB name=prettyGoodName  "}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=xfs    capacity=100GB name=prettyGoodName  "}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=lustre capacity=100GB name=prettyGoodName  "}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=raw    capacity=100TB name=prettyGoodName  "}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=xfs    capacity=100TB name=prettyGoodName  "}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=lustre capacity=100TB name=prettyGoodName  "}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=raw    capacity=100GB name=prettierGoodName"}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=xfs    capacity=100GB name=prettierGoodName"}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=lustre capacity=100GB name=prettierGoodName"}, allow, validDWOrAllowUnknownCommand},
 
-	{"#DW jobdw type=lustre capacity=100GB name=CoolProfile1 profile=this-TYPE_profile08", allow, validDWOrAllowUnknownCommand},
-	{"#DW jobdw type=lustre capacity=100GB name=CoolProfile2 profile=this_TYPE_profile08", allow, validDWOrAllowUnknownCommand},
-	{"#DW jobdw type=lustre capacity=100GB name=UncoolProfile1 profile=0this", deny, invalidDW},
-	{"#DW jobdw type=lustre capacity=100GB name=UncoolProfile2 profile=this!", deny, invalidDW},
-	{"#DW jobdw type=lustre capacity=100GB name=UncoolProfile3 profile=_this", deny, invalidDW},
-	{"#DW jobdw type=lustre capacity=100GB name=UncoolProfile4 profile=-this", deny, invalidDW},
+	{[]string{"#DW jobdw type=raw    capacity=100GB name=uniqueName1 ", "#DW jobdw type=raw    capacity=100GB name=uniqueName2 "}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=raw    capacity=100GB name=conflictName", "#DW jobdw type=raw    capacity=100GB name=conflictName"}, deny, invalidDW},
 
-	{"#DW jobdw type=lustre capacity=100GB combined_mgtmdt name=prettierGoodName", allow, validDWOrAllowUnknownCommand},
-	{"#DW jobdw type=lustre capacity=100GB combined_mgtmdt=true name=prettierGoodName", allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=lustre capacity=100GB name=CoolProfile1 profile=this-TYPE_profile08"}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=lustre capacity=100GB name=CoolProfile2 profile=this_TYPE_profile08"}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=lustre capacity=100GB name=UncoolProfile1 profile=0this"}, deny, invalidDW},
+	{[]string{"#DW jobdw type=lustre capacity=100GB name=UncoolProfile2 profile=this!"}, deny, invalidDW},
+	{[]string{"#DW jobdw type=lustre capacity=100GB name=UncoolProfile3 profile=_this"}, deny, invalidDW},
+	{[]string{"#DW jobdw type=lustre capacity=100GB name=UncoolProfile4 profile=-this"}, deny, invalidDW},
 
-	{"#DW jobdw type=lustre external_mgs=rabbit-01@tcp capacity=100GB name=Extern1", allow, validDWOrAllowUnknownCommand},
-	{"#DW jobdw type=lustre external_mgs=rabbit-01@tcp,rabbit-02@tcp:rabbit-03@tcp capacity=100GB name=Extern1", allow, validDWOrAllowUnknownCommand},
-	{"#DW jobdw type=lustre external_mgs=rabbit-01@tcp combined_mgtmdt capacity=100GB name=Extern1", allow, validDWOrAllowUnknownCommand},
-	{"#DW jobdw type=lustre external_mgs=rabbit-01@tcp0 capacity=100GB name=Extern1", allow, validDWOrAllowUnknownCommand},
-	{"#DW jobdw type=lustre external_mgs=10.0.0.1@o2ib capacity=100GB name=Extern2", allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=lustre capacity=100GB combined_mgtmdt name=prettierGoodName"}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=lustre capacity=100GB combined_mgtmdt=true name=prettierGoodName"}, allow, validDWOrAllowUnknownCommand},
 
-	{"#DW create_persistent type=raw    capacity=100GB name=prettyGoodName  ", deny, validDWOrAllowUnknownCommand},
-	{"#DW create_persistent type=xfs    capacity=100GB name=prettyGoodName  ", deny, validDWOrAllowUnknownCommand},
-	{"#DW create_persistent type=gfs2   capacity=100GB name=prettyGoodName  ", deny, validDWOrAllowUnknownCommand},
-	{"#DW create_persistent type=lustre capacity=100GB name=prettyGoodName  ", deny, validDWOrAllowUnknownCommand},
-	{"#DW create_persistent type=raw    capacity=100TB name=prettyGoodName  ", deny, validDWOrAllowUnknownCommand},
-	{"#DW create_persistent type=xfs    capacity=100TB name=prettyGoodName  ", deny, validDWOrAllowUnknownCommand},
-	{"#DW create_persistent type=lustre capacity=100TB name=prettyGoodName  ", deny, validDWOrAllowUnknownCommand},
-	{"#DW create_persistent type=raw    capacity=100GB name=prettierGoodName", deny, validDWOrAllowUnknownCommand},
-	{"#DW create_persistent type=xfs    capacity=100GB name=prettierGoodName", deny, validDWOrAllowUnknownCommand},
-	{"#DW create_persistent type=lustre capacity=100GB name=prettierGoodName", deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=lustre external_mgs=rabbit-01@tcp capacity=100GB name=Extern1"}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=lustre external_mgs=rabbit-01@tcp,rabbit-02@tcp:rabbit-03@tcp capacity=100GB name=Extern1"}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=lustre external_mgs=rabbit-01@tcp combined_mgtmdt capacity=100GB name=Extern1"}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=lustre external_mgs=rabbit-01@tcp0 capacity=100GB name=Extern1"}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=lustre external_mgs=10.0.0.1@o2ib capacity=100GB name=Extern2"}, allow, validDWOrAllowUnknownCommand},
 
-	{"#DW create_persistent type=raw    capacity=100GB name=prettyGoodName  ", allow, validDWOrAllowUnknownCommand},
-	{"#DW create_persistent type=xfs    capacity=100GB name=prettyGoodName  ", allow, validDWOrAllowUnknownCommand},
-	{"#DW create_persistent type=gfs2   capacity=100GB name=prettyGoodName  ", allow, validDWOrAllowUnknownCommand},
-	{"#DW create_persistent type=lustre capacity=100GB name=prettyGoodName  ", allow, validDWOrAllowUnknownCommand},
-	{"#DW create_persistent type=raw    capacity=100TB name=prettyGoodName  ", allow, validDWOrAllowUnknownCommand},
-	{"#DW create_persistent type=xfs    capacity=100TB name=prettyGoodName  ", allow, validDWOrAllowUnknownCommand},
-	{"#DW create_persistent type=lustre capacity=100TB name=prettyGoodName  ", allow, validDWOrAllowUnknownCommand},
-	{"#DW create_persistent type=raw    capacity=100GB name=prettierGoodName", allow, validDWOrAllowUnknownCommand},
-	{"#DW create_persistent type=xfs    capacity=100GB name=prettierGoodName", allow, validDWOrAllowUnknownCommand},
-	{"#DW create_persistent type=lustre capacity=100GB name=prettierGoodName", allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=raw    capacity=100GB name=prettyGoodName  "}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=xfs    capacity=100GB name=prettyGoodName  "}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=gfs2   capacity=100GB name=prettyGoodName  "}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=lustre capacity=100GB name=prettyGoodName  "}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=raw    capacity=100TB name=prettyGoodName  "}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=xfs    capacity=100TB name=prettyGoodName  "}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=lustre capacity=100TB name=prettyGoodName  "}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=raw    capacity=100GB name=prettierGoodName"}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=xfs    capacity=100GB name=prettierGoodName"}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=lustre capacity=100GB name=prettierGoodName"}, deny, validDWOrAllowUnknownCommand},
 
-	{"#DW create_persistent type=lustre capacity=100GB name=CoolProfile1 profile=this-TYPE_profile08", allow, validDWOrAllowUnknownCommand},
-	{"#DW create_persistent type=lustre capacity=100GB name=CoolProfile2 profile=this_TYPE_profile08", allow, validDWOrAllowUnknownCommand},
-	{"#DW create_persistent type=lustre capacity=100GB name=UncoolProfile1 profile=0this", deny, invalidDW},
-	{"#DW create_persistent type=lustre capacity=100GB name=UncoolProfile2 profile=this!", deny, invalidDW},
-	{"#DW create_persistent type=lustre capacity=100GB name=UncoolProfile3 profile=_this", deny, invalidDW},
-	{"#DW create_persistent type=lustre capacity=100GB name=UncoolProfile4 profile=-this", deny, invalidDW},
+	{[]string{"#DW create_persistent type=raw    capacity=100GB name=prettyGoodName  "}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=xfs    capacity=100GB name=prettyGoodName  "}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=gfs2   capacity=100GB name=prettyGoodName  "}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=lustre capacity=100GB name=prettyGoodName  "}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=raw    capacity=100TB name=prettyGoodName  "}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=xfs    capacity=100TB name=prettyGoodName  "}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=lustre capacity=100TB name=prettyGoodName  "}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=raw    capacity=100GB name=prettierGoodName"}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=xfs    capacity=100GB name=prettierGoodName"}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=lustre capacity=100GB name=prettierGoodName"}, allow, validDWOrAllowUnknownCommand},
 
-	{"#DW create_persistent type=lustre capacity=100GB combined_mgtmdt name=prettierGoodName", allow, validDWOrAllowUnknownCommand},
-	{"#DW create_persistent type=lustre capacity=100GB combined_mgtmdt=true name=prettierGoodName", allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=raw    capacity=100GB name=uniqueName1 ", "#DW create_persistent type=raw    capacity=100GB name=uniqueName2 "}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=raw    capacity=100GB name=conflictName", "#DW create_persistent type=raw    capacity=100GB name=conflictName"}, deny, invalidDW},
 
-	{"#DW create_persistent type=lustre external_mgs=rabbit-01@tcp capacity=100GB name=Extern1", allow, validDWOrAllowUnknownCommand},
-	{"#DW create_persistent type=lustre external_mgs=rabbit-01@tcp combined_mgtmdt capacity=100GB name=Extern1", allow, validDWOrAllowUnknownCommand},
-	{"#DW create_persistent type=lustre external_mgs=rabbit-01@tcp0 capacity=100GB name=Extern1", allow, validDWOrAllowUnknownCommand},
-	{"#DW create_persistent type=lustre external_mgs=10.0.0.1@o2ib capacity=100GB name=Extern2", allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=lustre capacity=100GB name=CoolProfile1 profile=this-TYPE_profile08"}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=lustre capacity=100GB name=CoolProfile2 profile=this_TYPE_profile08"}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=lustre capacity=100GB name=UncoolProfile1 profile=0this"}, deny, invalidDW},
+	{[]string{"#DW create_persistent type=lustre capacity=100GB name=UncoolProfile2 profile=this!"}, deny, invalidDW},
+	{[]string{"#DW create_persistent type=lustre capacity=100GB name=UncoolProfile3 profile=_this"}, deny, invalidDW},
+	{[]string{"#DW create_persistent type=lustre capacity=100GB name=UncoolProfile4 profile=-this"}, deny, invalidDW},
 
-	{"#DW stage_in  type=file      destination=$DW_JOB_STRIPED source=/pfs/dld-input ", deny, validDWOrAllowUnknownCommand},
-	{"#DW stage_in  type=directory destination=$DW_JOB_STRIPED source=/pfs/dld-input ", deny, validDWOrAllowUnknownCommand},
-	{"#DW stage_in  type=list      destination=$DW_JOB_STRIPED source=/pfs/dld-input ", deny, validDWOrAllowUnknownCommand},
-	{"#DW stage_out type=file      destination=/pfs/dld-output source=$DW_JOB_STRIPED", deny, validDWOrAllowUnknownCommand},
-	{"#DW stage_out type=directory destination=/pfs/dld-output source=$DW_JOB_STRIPED", deny, validDWOrAllowUnknownCommand},
-	{"#DW stage_out type=list      destination=/pfs/dld-output source=$DW_JOB_STRIPED", deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=lustre capacity=100GB combined_mgtmdt name=prettierGoodName"}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=lustre capacity=100GB combined_mgtmdt=true name=prettierGoodName"}, allow, validDWOrAllowUnknownCommand},
 
-	{"#DW stage_in  type=file      destination=$DW_JOB_STRIPED source=/pfs/dld-input ", allow, validDWOrAllowUnknownCommand},
-	{"#DW stage_in  type=directory destination=$DW_JOB_STRIPED source=/pfs/dld-input ", allow, validDWOrAllowUnknownCommand},
-	{"#DW stage_in  type=list      destination=$DW_JOB_STRIPED source=/pfs/dld-input ", allow, validDWOrAllowUnknownCommand},
-	{"#DW stage_out type=file      destination=/pfs/dld-output source=$DW_JOB_STRIPED", allow, validDWOrAllowUnknownCommand},
-	{"#DW stage_out type=directory destination=/pfs/dld-output source=$DW_JOB_STRIPED", allow, validDWOrAllowUnknownCommand},
-	{"#DW stage_out type=list      destination=/pfs/dld-output source=$DW_JOB_STRIPED", allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=lustre external_mgs=rabbit-01@tcp capacity=100GB name=Extern1"}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=lustre external_mgs=rabbit-01@tcp combined_mgtmdt capacity=100GB name=Extern1"}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=lustre external_mgs=rabbit-01@tcp0 capacity=100GB name=Extern1"}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=lustre external_mgs=10.0.0.1@o2ib capacity=100GB name=Extern2"}, allow, validDWOrAllowUnknownCommand},
 
-	{"#DW persistentdw name=evenBetterName", deny, validDWOrAllowUnknownCommand},
-	{"#DW persistentdw name=evenBetterName", allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW stage_in  type=file      destination=$DW_JOB_STRIPED source=/pfs/dld-input "}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW stage_in  type=directory destination=$DW_JOB_STRIPED source=/pfs/dld-input "}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW stage_in  type=list      destination=$DW_JOB_STRIPED source=/pfs/dld-input "}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW stage_out type=file      destination=/pfs/dld-output source=$DW_JOB_STRIPED"}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW stage_out type=directory destination=/pfs/dld-output source=$DW_JOB_STRIPED"}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW stage_out type=list      destination=/pfs/dld-output source=$DW_JOB_STRIPED"}, deny, validDWOrAllowUnknownCommand},
 
-	{"#DW destroy_persistent name=evenBetterName", deny, validDWOrAllowUnknownCommand},
-	{"#DW destroy_persistent name=evenBetterName", allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW stage_in  type=file      destination=$DW_JOB_STRIPED source=/pfs/dld-input "}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW stage_in  type=directory destination=$DW_JOB_STRIPED source=/pfs/dld-input "}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW stage_in  type=list      destination=$DW_JOB_STRIPED source=/pfs/dld-input "}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW stage_out type=file      destination=/pfs/dld-output source=$DW_JOB_STRIPED"}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW stage_out type=directory destination=/pfs/dld-output source=$DW_JOB_STRIPED"}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW stage_out type=list      destination=/pfs/dld-output source=$DW_JOB_STRIPED"}, allow, validDWOrAllowUnknownCommand},
 
-	{"#DW container name=mycontainer spec=some-repo-name                                                                         supervisor=rabbit", deny, validDWOrAllowUnknownCommand},
-	{"#DW container name=mycontainer spec=some-repo-name job_storage={stor1}                                                     supervisor=rabbit", deny, validDWOrAllowUnknownCommand},
-	{"#DW container name=mycontainer spec=some-repo-name job_storage={stor1,stor2,stor3}                                         supervisor=rabbit", deny, validDWOrAllowUnknownCommand},
-	{"#DW container name=mycontainer spec=some-repo-name                                 persistent_storage={perStore,perStore2} supervisor=rabbit", deny, validDWOrAllowUnknownCommand},
-	{"#DW container name=mycontainer spec=some-repo-name job_storage={stor1,stor2,stor3} persistent_storage={perStore,perStore2} supervisor=rabbit", deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW persistentdw name=evenBetterName"}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW persistentdw name=evenBetterName"}, allow, validDWOrAllowUnknownCommand},
 
-	{"                                                         ", deny, invalidDW},
-	{"    jobdw type=raw     capacity=100GB name=prettyGoodName", deny, invalidDW},
-	{"#DW       type=xfs     capacity=100TB name=noCommand     ", deny, invalidDW},
-	{"#DW bogus the_rest_does_not_matter                       ", deny, invalidDW},
-	{"#DW jobd  type=lustre  capacity=100TB name=badCommand    ", deny, invalidDW},
-	{"#DW jobdw tye=badtype  capacity=100TB name=badType       ", deny, invalidDW},
-	{"#DW jobdw type=badtype capacity=100TB name=badType       ", deny, invalidDW},
-	{"#DW jobdw              capacity=100TB name=missingType   ", deny, invalidDW},
-	{"#DW jobdw type=file    capacity=100TB name=badType       ", deny, invalidDW},
-	{"#DW jobdw type=raw     caacity=100TB  name=badCapacity   ", deny, invalidDW},
-	{"#DW jobdw type=raw     capacity=bad   name=badCapacity   ", deny, invalidDW},
-	{"#DW jobdw type=xfs     capacity=100TB ame=badName        ", deny, invalidDW},
-	{"#DW jobdw type=xfs     capacity=100TB name=!!21//\\      ", deny, invalidDW},
-	{"#DW jobdw                                                ", deny, invalidDW},
+	{[]string{"#DW destroy_persistent name=evenBetterName"}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW destroy_persistent name=evenBetterName"}, allow, validDWOrAllowUnknownCommand},
 
-	{"#DW jobdw type=raw type=raw capacity=100TB name=duplicatedTypes                         ", deny, invalidDW},
-	{"#DW jobdw type=raw capacity=100TB name=conflictingTypes type=xfs                        ", deny, invalidDW},
-	{"#DW jobdw type=badtype destination=shouldNotHaveDestination source=shouldNotHaveSource  ", deny, invalidDW},
+	{[]string{"#DW destroy_persistent name=uniqueName1 ", "#DW destroy_persistent name=uniqueName2 "}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW destroy_persistent name=conflictName", "#DW destroy_persistent name=conflictName"}, deny, invalidDW},
 
-	{"#DW stage_in  type=badtype destination=$DW_JOB_STRIPED source=/pfs/dld-input               ", deny, invalidDW},
-	{"#DW stage_out type=file    badkey=foobar destination=/pfs/dld-output source=$DW_JOB_STRIPED", deny, invalidDW},
+	{[]string{"#DW container name=mycontainer spec=some-repo-name                                                                         supervisor=rabbit"}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW container name=mycontainer spec=some-repo-name job_storage={stor1}                                                     supervisor=rabbit"}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW container name=mycontainer spec=some-repo-name job_storage={stor1,stor2,stor3}                                         supervisor=rabbit"}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW container name=mycontainer spec=some-repo-name                                 persistent_storage={perStore,perStore2} supervisor=rabbit"}, deny, validDWOrAllowUnknownCommand},
+	{[]string{"#DW container name=mycontainer spec=some-repo-name job_storage={stor1,stor2,stor3} persistent_storage={perStore,perStore2} supervisor=rabbit"}, deny, validDWOrAllowUnknownCommand},
 
-	{"#DW boguscommand the_rest_should_not_matter                                             ", allow, validDWOrAllowUnknownCommand},
-	{"#DW jobd  type=lustre  capacity=100TB name=badCommand                                   ", allow, validDWOrAllowUnknownCommand},
-	{"#DW stage_in type=badtype destination=$DW_JOB_STRIPED source=/pfs/dld-input             ", allow, invalidDW},
-	{"#DW stage_out type=file badkey=foobar destination=/pfs/dld-output source=$DW_JOB_STRIPED", allow, invalidDW},
-	{"#DW jobd  type=lustre  capacity=100TB name=badCommand                                   ", allow, validDWOrAllowUnknownCommand},
-	{"#DW jobdw tye=badtype  capacity=100TB name=badType                                      ", allow, invalidDW},
-	{"#DW jobdw type=badtype capacity=100TB name=badType                                      ", allow, invalidDW},
-	{"#DW jobdw              capacity=100TB name=missingType                                  ", allow, invalidDW},
-	{"#DW jobdw type=file    capacity=100TB name=badType                                      ", allow, invalidDW},
-	{"#DW jobdw type=raw     caacity=100TB  name=badCapacity                                  ", allow, invalidDW},
-	{"#DW jobdw type=raw     capacity=bad   name=badCapacity                                  ", allow, invalidDW},
-	{"#DW jobdw type=xfs     capacity=100TB ame=badName                                       ", allow, invalidDW},
-	{"#DW jobdw type=xfs     capacity=100TB name=!!21//\\                                     ", allow, invalidDW},
-	{"#DW jobdw                                                                               ", allow, invalidDW},
+	{[]string{"                                                         "}, deny, invalidDW},
+	{[]string{"    jobdw type=raw     capacity=100GB name=prettyGoodName"}, deny, invalidDW},
+	{[]string{"#DW       type=xfs     capacity=100TB name=noCommand     "}, deny, invalidDW},
+	{[]string{"#DW bogus the_rest_does_not_matter                       "}, deny, invalidDW},
+	{[]string{"#DW jobd  type=lustre  capacity=100TB name=badCommand    "}, deny, invalidDW},
+	{[]string{"#DW jobdw tye=badtype  capacity=100TB name=badType       "}, deny, invalidDW},
+	{[]string{"#DW jobdw type=badtype capacity=100TB name=badType       "}, deny, invalidDW},
+	{[]string{"#DW jobdw              capacity=100TB name=missingType   "}, deny, invalidDW},
+	{[]string{"#DW jobdw type=file    capacity=100TB name=badType       "}, deny, invalidDW},
+	{[]string{"#DW jobdw type=raw     caacity=100TB  name=badCapacity   "}, deny, invalidDW},
+	{[]string{"#DW jobdw type=raw     capacity=bad   name=badCapacity   "}, deny, invalidDW},
+	{[]string{"#DW jobdw type=xfs     capacity=100TB ame=badName        "}, deny, invalidDW},
+	{[]string{"#DW jobdw type=xfs     capacity=100TB name=!!21//\\      "}, deny, invalidDW},
+	{[]string{"#DW jobdw                                                "}, deny, invalidDW},
 
-	{"#DW container name=mycontainer spec=some-repo-name job_storage={stor1,} supervisor=rabbit", deny, invalidDW},
-	{"#DW container name=mycontainer spec=some-repo-name job_storage={,stor1} supervisor=rabbit", deny, invalidDW},
-	{"#DW container name=mycontainer ", deny, invalidDW},
+	{[]string{"#DW jobdw type=raw type=raw capacity=100TB name=duplicatedTypes                         "}, deny, invalidDW},
+	{[]string{"#DW jobdw type=raw capacity=100TB name=conflictingTypes type=xfs                        "}, deny, invalidDW},
+	{[]string{"#DW jobdw type=badtype destination=shouldNotHaveDestination source=shouldNotHaveSource  "}, deny, invalidDW},
+
+	{[]string{"#DW stage_in  type=badtype destination=$DW_JOB_STRIPED source=/pfs/dld-input               "}, deny, invalidDW},
+	{[]string{"#DW stage_out type=file    badkey=foobar destination=/pfs/dld-output source=$DW_JOB_STRIPED"}, deny, invalidDW},
+
+	{[]string{"#DW boguscommand the_rest_should_not_matter                                             "}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobd  type=lustre  capacity=100TB name=badCommand                                   "}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW stage_in type=badtype destination=$DW_JOB_STRIPED source=/pfs/dld-input             "}, allow, invalidDW},
+	{[]string{"#DW stage_out type=file badkey=foobar destination=/pfs/dld-output source=$DW_JOB_STRIPED"}, allow, invalidDW},
+	{[]string{"#DW jobd  type=lustre  capacity=100TB name=badCommand                                   "}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw tye=badtype  capacity=100TB name=badType                                      "}, allow, invalidDW},
+	{[]string{"#DW jobdw type=badtype capacity=100TB name=badType                                      "}, allow, invalidDW},
+	{[]string{"#DW jobdw              capacity=100TB name=missingType                                  "}, allow, invalidDW},
+	{[]string{"#DW jobdw type=file    capacity=100TB name=badType                                      "}, allow, invalidDW},
+	{[]string{"#DW jobdw type=raw     caacity=100TB  name=badCapacity                                  "}, allow, invalidDW},
+	{[]string{"#DW jobdw type=raw     capacity=bad   name=badCapacity                                  "}, allow, invalidDW},
+	{[]string{"#DW jobdw type=xfs     capacity=100TB ame=badName                                       "}, allow, invalidDW},
+	{[]string{"#DW jobdw type=xfs     capacity=100TB name=!!21//\\                                     "}, allow, invalidDW},
+	{[]string{"#DW jobdw                                                                               "}, allow, invalidDW},
+
+	{[]string{"#DW container name=mycontainer spec=some-repo-name job_storage={stor1,} supervisor=rabbit"}, deny, invalidDW},
+	{[]string{"#DW container name=mycontainer spec=some-repo-name job_storage={,stor1} supervisor=rabbit"}, deny, invalidDW},
+	{[]string{"#DW container name=mycontainer "}, deny, invalidDW},
 }
 
-func parsedw(t *testing.T, dwd string, dwRules []DWDirectiveRuleSpec, failUnknownCommand bool) error {
+func parsedw(t *testing.T, directiveList []string, dwRules []DWDirectiveRuleSpec, failUnknownCommand bool) error {
 
 	// Examine each rule. If there is an error with the rule, return that as a failure.
 	// Otherwise, continue looking at all the rules to see if you can find a valid rule
 	// recording whether we found one. If the DWDirective matches a rule without other errors,
 	// return succes.
-	directiveMatchesARule := false // Anticipate failure
-	for i := range dwRules {
-		valid, err := ValidateDWDirective(dWDRules[i], dwd, failUnknownCommand)
-		if err != nil {
-			return err // Errors indicate parsing problems, reject directive
+	uniqueMap := make(map[string]bool)
+
+	for _, directive := range directiveList {
+		directiveMatchesARule := false // Anticipate failure
+		for i := range dwRules {
+			valid, err := ValidateDWDirective(dWDRules[i], directive, uniqueMap, failUnknownCommand)
+			if err != nil {
+				return err // Errors indicate parsing problems, reject directive
+			}
+
+			// The directive matched a rule
+			if valid {
+				directiveMatchesARule = true
+			}
 		}
 
-		// The directive matched a rule
-		if valid {
-			directiveMatchesARule = true
+		if !directiveMatchesARule {
+			return fmt.Errorf("invalid directive found: %s", directive)
 		}
-	}
-
-	if !directiveMatchesARule {
-		return fmt.Errorf("invalid directive found: %s", dwd)
 	}
 
 	return nil
@@ -414,13 +430,13 @@ func parsedw(t *testing.T, dwd string, dwRules []DWDirectiveRuleSpec, failUnknow
 func TestDWParse(t *testing.T) {
 	for index, tt := range dwDirectiveTests {
 		validCommand := false
-		err := parsedw(t, tt.directive, dWDRules, tt.failUnknownCommand)
+		err := parsedw(t, tt.directiveList, dWDRules, tt.failUnknownCommand)
 		if err == nil {
 			validCommand = true
 		}
 
 		if validCommand != tt.validCommand {
-			t.Errorf("TestDWParse(%s)(%d): allowUnsupportedCommand(%v) expect_valid(%v) err(%v)", tt.directive, index, tt.failUnknownCommand, tt.validCommand, err)
+			t.Errorf("TestDWParse(%s)(%d): allowUnsupportedCommand(%v) expect_valid(%v) err(%v)", tt.directiveList, index, tt.failUnknownCommand, tt.validCommand, err)
 		}
 	}
 }

--- a/utils/dwdparse/dwdparse_test.go
+++ b/utils/dwdparse/dwdparse_test.go
@@ -267,8 +267,10 @@ var dwDirectiveTests = []struct {
 	{[]string{"#DW jobdw type=xfs    capacity=100GB name=prettierGoodName"}, allow, validDWOrAllowUnknownCommand},
 	{[]string{"#DW jobdw type=lustre capacity=100GB name=prettierGoodName"}, allow, validDWOrAllowUnknownCommand},
 
-	{[]string{"#DW jobdw type=raw    capacity=100GB name=uniqueName1 ", "#DW jobdw type=raw    capacity=100GB name=uniqueName2 "}, allow, validDWOrAllowUnknownCommand},
-	{[]string{"#DW jobdw type=raw    capacity=100GB name=conflictName", "#DW jobdw type=raw    capacity=100GB name=conflictName"}, deny, invalidDW},
+	{[]string{"#DW jobdw type=raw    capacity=100GB name=uniqueName1 ",
+		"#DW jobdw type=raw    capacity=100GB name=uniqueName2 "}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW jobdw type=raw    capacity=100GB name=conflictName",
+		"#DW jobdw type=raw    capacity=100GB name=conflictName"}, deny, invalidDW},
 
 	{[]string{"#DW jobdw type=lustre capacity=100GB name=CoolProfile1 profile=this-TYPE_profile08"}, allow, validDWOrAllowUnknownCommand},
 	{[]string{"#DW jobdw type=lustre capacity=100GB name=CoolProfile2 profile=this_TYPE_profile08"}, allow, validDWOrAllowUnknownCommand},
@@ -308,8 +310,10 @@ var dwDirectiveTests = []struct {
 	{[]string{"#DW create_persistent type=xfs    capacity=100GB name=prettierGoodName"}, allow, validDWOrAllowUnknownCommand},
 	{[]string{"#DW create_persistent type=lustre capacity=100GB name=prettierGoodName"}, allow, validDWOrAllowUnknownCommand},
 
-	{[]string{"#DW create_persistent type=raw    capacity=100GB name=uniqueName1 ", "#DW create_persistent type=raw    capacity=100GB name=uniqueName2 "}, allow, validDWOrAllowUnknownCommand},
-	{[]string{"#DW create_persistent type=raw    capacity=100GB name=conflictName", "#DW create_persistent type=raw    capacity=100GB name=conflictName"}, deny, invalidDW},
+	{[]string{"#DW create_persistent type=raw    capacity=100GB name=uniqueName1 ",
+		"#DW create_persistent type=raw    capacity=100GB name=uniqueName2 "}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW create_persistent type=raw    capacity=100GB name=conflictName",
+		"#DW create_persistent type=raw    capacity=100GB name=conflictName"}, deny, invalidDW},
 
 	{[]string{"#DW create_persistent type=lustre capacity=100GB name=CoolProfile1 profile=this-TYPE_profile08"}, allow, validDWOrAllowUnknownCommand},
 	{[]string{"#DW create_persistent type=lustre capacity=100GB name=CoolProfile2 profile=this_TYPE_profile08"}, allow, validDWOrAllowUnknownCommand},
@@ -346,8 +350,10 @@ var dwDirectiveTests = []struct {
 	{[]string{"#DW destroy_persistent name=evenBetterName"}, deny, validDWOrAllowUnknownCommand},
 	{[]string{"#DW destroy_persistent name=evenBetterName"}, allow, validDWOrAllowUnknownCommand},
 
-	{[]string{"#DW destroy_persistent name=uniqueName1 ", "#DW destroy_persistent name=uniqueName2 "}, allow, validDWOrAllowUnknownCommand},
-	{[]string{"#DW destroy_persistent name=conflictName", "#DW destroy_persistent name=conflictName"}, deny, invalidDW},
+	{[]string{"#DW destroy_persistent name=uniqueName1 ",
+		"#DW destroy_persistent name=uniqueName2 "}, allow, validDWOrAllowUnknownCommand},
+	{[]string{"#DW destroy_persistent name=conflictName",
+		"#DW destroy_persistent name=conflictName"}, deny, invalidDW},
 
 	{[]string{"#DW container name=mycontainer spec=some-repo-name                                                                         supervisor=rabbit"}, deny, validDWOrAllowUnknownCommand},
 	{[]string{"#DW container name=mycontainer spec=some-repo-name job_storage={stor1}                                                     supervisor=rabbit"}, deny, validDWOrAllowUnknownCommand},


### PR DESCRIPTION
This commit adds a new option for a rule definition, "uniqueWithin". This
option allows rules to specify that a key/value pair needs to be unique across
multiple #DWs. An example is the "name" field in a jobdw directive. Multiple
jobdws should not use the same value for name. However, The same value for name
can be used between a jobdw and a create_persistent. "uniqueBetween" allows for
this by specifying a key. Values will only be checked for uniqueness for rule
definitions using the same "uniqueBetween" key.

Signed-off-by: Matt Richerson <mattr@cray.com>