### PR TITLE
Refactor error handling in updater logic

### DIFF
--- a/api/v1alpha1/directivebreakdown_types.go
+++ b/api/v1alpha1/directivebreakdown_types.go
@@ -21,7 +21,7 @@ package v1alpha1
 
 import (
 	"github.com/HewlettPackard/dws/utils/updater"
-	
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/api/v1alpha1/directivebreakdown_types.go
+++ b/api/v1alpha1/directivebreakdown_types.go
@@ -20,6 +20,8 @@
 package v1alpha1
 
 import (
+	"github.com/HewlettPackard/dws/utils/updater"
+	
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -156,6 +158,10 @@ type DirectiveBreakdown struct {
 
 	Spec   DirectiveBreakdownSpec   `json:"spec,omitempty"`
 	Status DirectiveBreakdownStatus `json:"status,omitempty"`
+}
+
+func (db *DirectiveBreakdown) GetStatus() updater.Status[*DirectiveBreakdownStatus] {
+	return &db.Status
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1alpha1/persistentstorageinstance_types.go
+++ b/api/v1alpha1/persistentstorageinstance_types.go
@@ -71,7 +71,6 @@ type PersistentStorageInstanceStatus struct {
 	Servers corev1.ObjectReference `json:"servers,omitempty"`
 	// Current state of the PersistentStorageInstance
 	// +kubebuilder:validation:Enum=creating;active;deleting
-	// +kubebuilder:default:=creating
 	State PersistentStorageInstanceState `json:"state"`
 }
 

--- a/api/v1alpha1/persistentstorageinstance_types.go
+++ b/api/v1alpha1/persistentstorageinstance_types.go
@@ -20,6 +20,8 @@
 package v1alpha1
 
 import (
+	"github.com/HewlettPackard/dws/utils/updater"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -83,6 +85,10 @@ type PersistentStorageInstance struct {
 
 	Spec   PersistentStorageInstanceSpec   `json:"spec,omitempty"`
 	Status PersistentStorageInstanceStatus `json:"status,omitempty"`
+}
+
+func (psi *PersistentStorageInstance) GetStatus() updater.Status[*PersistentStorageInstanceStatus] {
+	return &psi.Status
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/dws.cray.hpe.com_persistentstorageinstances.yaml
+++ b/config/crd/bases/dws.cray.hpe.com_persistentstorageinstances.yaml
@@ -100,7 +100,6 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               state:
-                default: creating
                 description: Current state of the PersistentStorageInstance
                 enum:
                 - creating

--- a/controllers/clientmount_controller.go
+++ b/controllers/clientmount_controller.go
@@ -66,11 +66,7 @@ func (r *ClientMountReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// Create a status updater that handles the call to r.Status().Update() if any of the fields
 	// in clientMount.Status{} change
 	statusUpdater := updater.NewStatusUpdater[*dwsv1alpha1.ClientMountStatus](clientMount)
-	defer func() {
-		if err == nil {
-			err = statusUpdater.CloseWithStatusUpdate(ctx, r)
-		}
-	}()
+	defer func() { err = statusUpdater.CloseWithStatusUpdate(ctx, r, err) }()
 
 	// Handle cleanup if the resource is being deleted
 	if !clientMount.GetDeletionTimestamp().IsZero() {

--- a/controllers/workflow_controller.go
+++ b/controllers/workflow_controller.go
@@ -90,11 +90,7 @@ func (r *WorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 	// in workflow.Status{} change. This is necessary since Status is not a subresource
 	// of the workflow.
 	statusUpdater := updater.NewStatusUpdater[*dwsv1alpha1.WorkflowStatus](workflow)
-	defer func() {
-		if err == nil {
-			err = statusUpdater.CloseWithUpdate(ctx, r)
-		}
-	}()
+	defer func() { err = statusUpdater.CloseWithUpdate(ctx, r, err) }()
 
 	// Check if the object is being deleted
 	if !workflow.GetDeletionTimestamp().IsZero() {

--- a/mount-daemon/controllers/clientmount_controller.go
+++ b/mount-daemon/controllers/clientmount_controller.go
@@ -73,11 +73,7 @@ func (r *ClientMountReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	// Create a status updater that handles the call to r.Status().Update() if any of the fields
 	// in clientMount.Status{} change
 	statusUpdater := updater.NewStatusUpdater[*dwsv1alpha1.ClientMountStatus](clientMount)
-	defer func() {
-		if err == nil {
-			err = statusUpdater.CloseWithStatusUpdate(ctx, r)
-		}
-	}()
+	defer func() { err = statusUpdater.CloseWithStatusUpdate(ctx, r, err) }()
 
 	// Handle cleanup if the resource is being deleted
 	if !clientMount.GetDeletionTimestamp().IsZero() {

--- a/utils/updater/status_updater.go
+++ b/utils/updater/status_updater.go
@@ -74,31 +74,39 @@ func NewStatusUpdater[S Status[S]](rsrc resource[S]) *statusUpdater[S] {
 // changed from the initially recorded status. CloseWithUpdate will NOT return an error
 // if there is a resource conflict on this version of the resource. The reconciler will
 // already have an event queued for the new version of the resource.
-func (updater *statusUpdater[S]) CloseWithUpdate(ctx context.Context, c client.Writer) error {
-	return updater.close(ctx, c)
+func (updater *statusUpdater[S]) CloseWithUpdate(ctx context.Context, c client.Writer, err error) error {
+	return updater.close(ctx, c, err)
 }
 
 // CloseWithStatusUpdate will attempt to update the resource's status if any of the status
 // fields have changed from the initially recorded status. CloseWithStatusUpdate will NOT
 // return an error if there is a resource conflict on this version of the resource. The
 // reconciler will already have an event queued for the new version of the resource.
-func (updater *statusUpdater[S]) CloseWithStatusUpdate(ctx context.Context, c client.StatusClient) error {
-	return updater.close(ctx, c.Status())
+func (updater *statusUpdater[S]) CloseWithStatusUpdate(ctx context.Context, c client.StatusClient, err error) error {
+	return updater.close(ctx, c.Status(), err)
 }
 
 type clientUpdater interface {
 	Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error
 }
 
-func (updater *statusUpdater[S]) close(ctx context.Context, c clientUpdater) error {
+func (updater *statusUpdater[S]) close(ctx context.Context, c clientUpdater, err error) error {
 	if !reflect.DeepEqual(updater.resource.GetStatus(), updater.status) {
-		err := c.Update(ctx, updater.resource)
 
-		// Do not return an error if there is a resource conflict on this version of the resource.
-		// The reconciler will already have an event queued for the new version of the resource.
-		if !errors.IsConflict(err) {
-			return err
+		// Always attempt an update to the resource even in the presence of different error, but
+		// do not override the original error if present.
+		updateError := c.Update(ctx, updater.resource)
+
+		if err == nil {
+			// Do not return an error if there is a resource conflict on this version of the resource.
+			// The reconciler will already have an event queued for the new version of the resource.
+			if !errors.IsConflict(updateError) {
+				return updateError
+			}
 		}
+
+		return err
+
 	}
 
 	return nil

--- a/utils/updater/status_updater_test.go
+++ b/utils/updater/status_updater_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -64,18 +65,21 @@ func (*testWriter) Update(ctx context.Context, obj client.Object, opts ...client
 
 func (*testWriter) Status() client.StatusWriter { return &testStatusWriter{} }
 
-func TestUpdate(t *testing.T)   { testUpdate(t, true) }
-func TestNoUpdate(t *testing.T) { testUpdate(t, false) }
+func TestUpdate(t *testing.T)          { testUpdate(t, true, nil) }
+func TestUpdateWithError(t *testing.T) { testUpdate(t, true, errors.Errorf("err")) }
+func TestNoUpdate(t *testing.T)        { testUpdate(t, false, nil) }
 
 // Test that when a change occurs to the object's status, only the object is updated
 // and not the status
-func testUpdate(t *testing.T, changed bool) {
+func testUpdate(t *testing.T, changed bool, err error) {
 	obj := &testObject{updated: false}
 	updater := NewStatusUpdater[*testStatus](obj)
 
 	obj.status.changed = changed
 
-	updater.CloseWithUpdate(context.TODO(), &testWriter{}, nil)
+	if updateErr := updater.CloseWithUpdate(context.TODO(), &testWriter{}, err); updateErr != err {
+		t.Errorf("Close expected error %v, not %v", err, updateErr)
+	}
 
 	if obj.updated != changed {
 		t.Errorf("Test object not updated")
@@ -101,18 +105,21 @@ func (*testStatusWriter) Update(ctx context.Context, obj client.Object, opts ...
 	return nil
 }
 
-func TestStatusUpdate(t *testing.T)   { testStatusUpdate(t, true) }
-func TestNoStatusUpdate(t *testing.T) { testStatusUpdate(t, false) }
+func TestStatusUpdate(t *testing.T)          { testStatusUpdate(t, true, nil) }
+func TestStatusUpdateWithError(t *testing.T) { testStatusUpdate(t, true, errors.Errorf("err")) }
+func TestNoStatusUpdate(t *testing.T)        { testStatusUpdate(t, false, nil) }
 
 // Test when a change occurs to an object's status, only the status fields are
 // updated and not the object.
-func testStatusUpdate(t *testing.T, changed bool) {
+func testStatusUpdate(t *testing.T, changed bool, err error) {
 	obj := &testObject{updated: false}
 	updater := NewStatusUpdater[*testStatus](obj)
 
 	obj.status.changed = changed // toggle the status changed field so the update occurs
 
-	updater.CloseWithStatusUpdate(context.TODO(), &testWriter{}, nil)
+	if updateErr := updater.CloseWithStatusUpdate(context.TODO(), &testWriter{}, err); updateErr != err {
+		t.Errorf("Close expected error %v, not %v", err, updateErr)
+	}
 
 	if obj.updated {
 		t.Errorf("Test object incorrectly updated")

--- a/utils/updater/status_updater_test.go
+++ b/utils/updater/status_updater_test.go
@@ -75,7 +75,7 @@ func testUpdate(t *testing.T, changed bool) {
 
 	obj.status.changed = changed
 
-	updater.CloseWithUpdate(context.TODO(), &testWriter{})
+	updater.CloseWithUpdate(context.TODO(), &testWriter{}, nil)
 
 	if obj.updated != changed {
 		t.Errorf("Test object not updated")
@@ -112,7 +112,7 @@ func testStatusUpdate(t *testing.T, changed bool) {
 
 	obj.status.changed = changed // toggle the status changed field so the update occurs
 
-	updater.CloseWithStatusUpdate(context.TODO(), &testWriter{})
+	updater.CloseWithStatusUpdate(context.TODO(), &testWriter{}, nil)
 
 	if obj.updated {
 		t.Errorf("Test object incorrectly updated")


### PR DESCRIPTION
Talking with @matthew-richerson we want to always make the best attempt to update in the `Close()` routine even when an error is present, but never to override the original error with the Update() error.

This change permits that in the updater code and converts the 3 updater users in DWS to that new API.