### PR TITLE
Install the envtest tools into the bin/ dir of the repo, so they are …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ IMG ?= $(IMAGE_TAG_BASE):$(VERSION)
 OVERLAY ?= kind
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.24.2
+ENVTEST_K8S_VERSION = 1.25.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -127,7 +127,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(LOCALBIN))" go test ./... -coverprofile cover.out
 
 ##@ Build
 build-daemon: manifests generate fmt vet ## Build standalone clientMount daemon


### PR DESCRIPTION
…available

when debugging from within VSCode.

Upgrade to envtest 1.25.0.