### PR TITLE
RABSW-1011: Expect test workflow status to be "Completed"

### DIFF
--- a/controllers/workflow_controller_test.go
+++ b/controllers/workflow_controller_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Workflow Controller Test", func() {
 		Eventually(func(g Gomega) string {
 			g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(wf), wf)).To(Succeed())
 			return wf.Status.Status
-		}).Should(Equal(dwsv1alpha1.StatusDriverWait))
+		}).Should(Equal(dwsv1alpha1.StatusCompleted))
 
 	})
 })


### PR DESCRIPTION
The workflow_controller_test.go should expect the workflow with an invalid directive to reach state "Completed". No drivers are registered, so there's nothing to wait for.

Signed-off-by: Matt Richerson <matthew.richerson@Matts-MacBook-Pro.local>