### PR TITLE
Add spec file and build RPMs in github action (#54)

### DIFF
--- a/.github/workflows/rpm_build.yml
+++ b/.github/workflows/rpm_build.yml
@@ -1,0 +1,37 @@
+name: RPM Build
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: centos:8
+      env:
+        NODE_ENV: development
+      ports:
+        - 80
+      options: --cpus 1
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: environment setup
+        run: |
+          dnf -y --disablerepo '*' --enablerepo=extras swap centos-linux-repos centos-stream-repos
+          dnf -y distro-sync
+          dnf -y makecache --refresh
+          dnf install -y rpm-build rpmdevtools git make
+          dnf module -y install go-toolset 
+          rpmdev-setuptree
+          tar -czf /github/home/rpmbuild/SOURCES/dws-clientmount-1.0.tar.gz --transform 's,^,dws-clientmount-1.0/,' .
+      - name: build rpms
+        run: rpmbuild -ba clientmount.spec
+      - name: upload rpms
+        uses: actions/upload-artifact@v3
+        with:
+          name: dws-clientmount-1.0-1.el8.x86_64.rpm
+          path: /github/home/rpmbuild/RPMS/x86_64/dws-clientmount-1.0-1.el8.x86_64.rpm
+      - name: upload srpms
+        uses: actions/upload-artifact@v3
+        with:
+          name: dws-clientmount-1.0-1.el8.src.rpm
+          path: /github/home/rpmbuild/SRPMS/dws-clientmount-1.0-1.el8.src.rpm

--- a/clientmount.spec
+++ b/clientmount.spec
@@ -1,0 +1,32 @@
+%undefine _missing_build_ids_terminate_build
+%global debug_package %{nil}
+
+Name: dws-clientmount
+Version: 1.0
+Release: 1%{?dist}
+Summary: Client mount daemon for data workflow service
+
+Group: 1
+License: Apache-2.0
+URL: https://github.com/HewlettPackard/dws
+Source0: %{name}-%{version}.tar.gz
+
+BuildRequires:	golang
+BuildRequires:	make
+
+%description
+This package provides clientmountd for performing mount operations for the
+data workflow service
+
+%prep
+%setup -q
+
+%build
+make build-daemon
+
+%install
+mkdir -p %{buildroot}/usr/bin/
+install -m 755 bin/clientmountd %{buildroot}/usr/bin/clientmountd
+
+%files
+/usr/bin/clientmountd


### PR DESCRIPTION
This commit adds a spec file to package the clientmount daemon. I added a github action that builds the binary and source RPMs and saves them as an artifact.

Signed-off-by: Matt Richerson <matthew.richerson@Matts-MacBook-Pro.local>