### PR TITLE
Add a hurry flag to the workflow spec.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ env:
   TEST_TARGET: testing
 
   # DO_TEST - true to build and run unit tests, false to skip the tests
-  DO_TEST: false
+  DO_TEST: true
 
   # DO_PUSH - true to push to the HPE_DEPLOY_REPO, false to not push
   DO_PUSH: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,15 @@ COPY vendor/ vendor/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
+FROM builder as testing
+WORKDIR /workspace
+
+COPY hack/ hack/
+COPY Makefile .
+
+RUN echo "building test target after copy" && pwd && ls -al
+ENTRYPOINT ["make", "test"]
+
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot

--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,10 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+container-unit-test: ## Build docker image with the manager and execute unit tests.
+	${DOCKER} build -f Dockerfile --label $(IMAGE_TAG_BASE)-$@:$(VERSION)-$@ -t $(IMAGE_TAG_BASE)-$@:$(VERSION) --target testing .
+	${DOCKER} run --rm -t --name $@-nnf-sos  $(IMAGE_TAG_BASE)-$@:$(VERSION)
+
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(LOCALBIN))" go test ./... -coverprofile cover.out
 

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -103,6 +103,7 @@ var _ = BeforeSuite(func() {
 	//+kubebuilder:scaffold:webhook
 
 	go func() {
+		defer GinkgoRecover()
 		err = mgr.Start(ctx)
 		if err != nil {
 			Expect(err).NotTo(HaveOccurred())

--- a/api/v1alpha1/workflow_types.go
+++ b/api/v1alpha1/workflow_types.go
@@ -104,6 +104,12 @@ type WorkflowSpec struct {
 	// conjunction with User ID to run subtasks with UserID:GroupID credentials.
 	GroupID uint32 `json:"groupID"`
 
+	// Hurry indicates that the workflow's driver should kill the job in a hurry when this workflow enters its teardown state.
+	// The driver must release all resources and unmount any filesystems that were mounted as part of the workflow, though some drivers would have done this anyway as part of their teardown state.
+	// The driver must also kill any in-progress data transfers, or skip any data transfers that have not yet begun.
+	// +kubebuilder:default:=false
+	Hurry bool `json:"hurry"`
+
 	// List of #DW strings from a WLM job script
 	DWDirectives []string `json:"dwDirectives"`
 }
@@ -137,7 +143,7 @@ type WorkflowDriverStatus struct {
 type WorkflowStatus struct {
 	// The state the resource is currently transitioning to.
 	// Updated by the controller once started.
-	// +kubebuilder:default=proposal
+	// +kubebuilder:default:=proposal
 	State string `json:"state"`
 
 	// Ready can be 'True', 'False'

--- a/api/v1alpha1/workflow_webhook.go
+++ b/api/v1alpha1/workflow_webhook.go
@@ -80,7 +80,7 @@ func (w *Workflow) ValidateCreate() error {
 		return fmt.Errorf("desired state must start in %s", StateProposal.String())
 	}
 	if w.Spec.Hurry == true {
-		return fmt.Errorf("The hurry flag may not be set on creation")
+		return fmt.Errorf("the hurry flag may not be set on creation")
 	}
 
 	return checkDirectives(w, &ValidatingRuleParser{})
@@ -98,7 +98,7 @@ func (w *Workflow) ValidateUpdate(old runtime.Object) error {
 	}
 
 	if w.Spec.Hurry == true && w.Spec.DesiredState != StateTeardown.String() {
-		return fmt.Errorf("The hurry flag may only be set for %s", StateTeardown.String())
+		return fmt.Errorf("the hurry flag may only be set for %s", StateTeardown.String())
 	}
 
 	// Check that immutable fields haven't changed.
@@ -118,7 +118,7 @@ func (w *Workflow) ValidateUpdate(old runtime.Object) error {
 		// Elements with watchStates not equal to the current state should not change
 		if driverStatus.WatchState != oldWorkflow.Status.State {
 			if !reflect.DeepEqual(oldWorkflow.Status.Drivers[i], driverStatus) {
-				return fmt.Errorf("Driver entry for non-current state cannot be changed")
+				return fmt.Errorf("driver entry for non-current state cannot be changed")
 			}
 
 			continue
@@ -126,15 +126,15 @@ func (w *Workflow) ValidateUpdate(old runtime.Object) error {
 
 		if driverStatus.Completed == true {
 			if driverStatus.Status != StatusCompleted {
-				return fmt.Errorf("Driver cannot be completed without status=Completed")
+				return fmt.Errorf("driver cannot be completed without status=Completed")
 			}
 
 			if driverStatus.Error != "" {
-				return fmt.Errorf("Driver cannot be completed when error is present")
+				return fmt.Errorf("driver cannot be completed when error is present")
 			}
 		} else {
 			if oldWorkflow.Status.Drivers[i].Completed == true {
-				return fmt.Errorf("Driver cannot change from completed state")
+				return fmt.Errorf("driver cannot change from completed state")
 			}
 		}
 	}
@@ -270,7 +270,7 @@ func (r *RuleList) ReadRules() error {
 	}
 
 	if len(ruleSetList.Items) == 0 {
-		return fmt.Errorf("Unable to find ruleset in namespace: %s", ns)
+		return fmt.Errorf("unable to find ruleset in namespace: %s", ns)
 	}
 
 	r.rules = []dwdparse.DWDirectiveRuleSpec{}

--- a/api/v1alpha1/workflow_webhook_test.go
+++ b/api/v1alpha1/workflow_webhook_test.go
@@ -69,13 +69,4 @@ var _ = Describe("Workflow Webhook", func() {
 		Expect(k8sClient.Create(context.TODO(), workflow)).ToNot(Succeed())
 		workflow = nil
 	})
-
-	It("Create workflow, then fail to update hurry flag", func() {
-		Expect(k8sClient.Create(context.TODO(), workflow)).To(Succeed())
-		Eventually(func(g Gomega) {
-			g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(workflow), workflow)).To(Succeed())
-		}).Should(Succeed(), "get new workflow")
-		workflow.Spec.Hurry = true
-		Expect(k8sClient.Update(context.TODO(), workflow)).ToNot(Succeed())
-	})
 })

--- a/api/v1alpha1/workflow_webhook_test.go
+++ b/api/v1alpha1/workflow_webhook_test.go
@@ -21,10 +21,13 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // These tests are written in BDD-style using Ginkgo framework. Refer to
@@ -36,9 +39,10 @@ var _ = Describe("Workflow Webhook", func() {
 	)
 
 	BeforeEach(func() {
+		wfid := uuid.NewString()[0:8]
 		workflow = &Workflow{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
+				Name:      fmt.Sprintf("w%s", wfid),
 				Namespace: metav1.NamespaceDefault,
 			},
 			Spec: WorkflowSpec{
@@ -46,17 +50,32 @@ var _ = Describe("Workflow Webhook", func() {
 				DWDirectives: []string{},
 			},
 		}
-
-		Expect(k8sClient.Create(context.TODO(), workflow)).To(Succeed())
 	})
 
 	AfterEach(func() {
-		Expect(k8sClient.Delete(context.TODO(), workflow)).To(Succeed())
+		if workflow != nil {
+			Expect(k8sClient.Delete(context.TODO(), workflow)).To(Succeed())
+		}
 	})
 
 	It("should have workflow environmental variables set successfully", func() {
+		Expect(k8sClient.Create(context.TODO(), workflow)).To(Succeed())
 		Expect(workflow.Status.Env).To(HaveKeyWithValue("DW_WORKFLOW_NAME", workflow.Name))
 		Expect(workflow.Status.Env).To(HaveKeyWithValue("DW_WORKFLOW_NAMESPACE", workflow.Namespace))
 	})
 
+	It("Fails to create workflow with hurry flag set", func() {
+		workflow.Spec.Hurry = true
+		Expect(k8sClient.Create(context.TODO(), workflow)).ToNot(Succeed())
+		workflow = nil
+	})
+
+	It("Create workflow, then fail to update hurry flag", func() {
+		Expect(k8sClient.Create(context.TODO(), workflow)).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(workflow), workflow)).To(Succeed())
+		}).Should(Succeed(), "get new workflow")
+		workflow.Spec.Hurry = true
+		Expect(k8sClient.Update(context.TODO(), workflow)).ToNot(Succeed())
+	})
 })

--- a/api/v1alpha1/workflow_webhook_test.go
+++ b/api/v1alpha1/workflow_webhook_test.go
@@ -27,7 +27,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // These tests are written in BDD-style using Ginkgo framework. Refer to

--- a/config/crd/bases/dws.cray.hpe.com_workflows.yaml
+++ b/config/crd/bases/dws.cray.hpe.com_workflows.yaml
@@ -96,6 +96,16 @@ spec:
                   with User ID to run subtasks with UserID:GroupID credentials.
                 format: int32
                 type: integer
+              hurry:
+                default: false
+                description: Hurry indicates that the workflow's driver should kill
+                  the job in a hurry when this workflow enters its teardown state.
+                  The driver must release all resources and unmount any filesystems
+                  that were mounted as part of the workflow, though some drivers would
+                  have done this anyway as part of their teardown state. The driver
+                  must also kill any in-progress data transfers, or skip any data
+                  transfers that have not yet begun.
+                type: boolean
               jobID:
                 type: integer
               userID:
@@ -111,6 +121,7 @@ spec:
             - desiredState
             - dwDirectives
             - groupID
+            - hurry
             - jobID
             - userID
             - wlmID

--- a/controllers/workflow_controller_test.go
+++ b/controllers/workflow_controller_test.go
@@ -2,7 +2,9 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -14,24 +16,41 @@ import (
 )
 
 var _ = Describe("Workflow Controller Test", func() {
-	It("Creates workflow", func() {
-		wf := &dwsv1alpha1.Workflow{
+
+	var (
+		wf *dwsv1alpha1.Workflow
+	)
+
+	BeforeEach(func() {
+		wfid := uuid.NewString()[0:8]
+		wf = &dwsv1alpha1.Workflow{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
+				Name:      fmt.Sprintf("%s", wfid),
 				Namespace: corev1.NamespaceDefault,
 			},
 			Spec: dwsv1alpha1.WorkflowSpec{
-				DesiredState: "proposal",
+				DesiredState: dwsv1alpha1.StateProposal.String(),
 				WLMID:        "test",
 				JobID:        0,
 				UserID:       0,
 				GroupID:      0,
-				DWDirectives: []string{
-					"Sup Yo",
-				},
+				DWDirectives: []string{},
 			},
 		}
+	})
 
+	AfterEach(func() {
+		if wf != nil {
+			Expect(k8sClient.Delete(context.TODO(), wf)).To(Succeed())
+
+			wfExpected := &dwsv1alpha1.Workflow{}
+			Eventually(func() error { // Delete can still return the cached object. Wait until the object is no longer present.
+				return k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(wf), wfExpected)
+			}).ShouldNot(Succeed())
+		}
+	})
+
+	It("Creates workflow", func() {
 		Expect(k8sClient.Create(context.TODO(), wf)).To(Succeed())
 
 		Eventually(func(g Gomega) string {
@@ -39,5 +58,36 @@ var _ = Describe("Workflow Controller Test", func() {
 			return wf.Status.Status
 		}).Should(Equal(dwsv1alpha1.StatusCompleted))
 
+	})
+
+	It("Fails to create workflow with hurry flag set", func() {
+		wf.Spec.Hurry = true
+		Expect(k8sClient.Create(context.TODO(), wf)).ToNot(Succeed())
+		wf = nil
+	})
+
+	It("Creates workflow, then fails to add hurry flag", func() {
+		Expect(k8sClient.Create(context.TODO(), wf)).To(Succeed())
+
+		Eventually(func(g Gomega) string {
+			g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(wf), wf)).To(Succeed())
+			return wf.Status.Status
+		}).Should(Equal(dwsv1alpha1.StatusCompleted))
+
+		wf.Spec.Hurry = true
+		Expect(k8sClient.Update(context.TODO(), wf)).ToNot(Succeed())
+	})
+
+	It("Creates workflow, goes to teardown with hurry flag", func() {
+		Expect(k8sClient.Create(context.TODO(), wf)).To(Succeed())
+
+		Eventually(func(g Gomega) string {
+			g.Expect(k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(wf), wf)).To(Succeed())
+			return wf.Status.Status
+		}).Should(Equal(dwsv1alpha1.StatusCompleted))
+
+		wf.Spec.DesiredState = dwsv1alpha1.StateTeardown.String()
+		wf.Spec.Hurry = true
+		Expect(k8sClient.Update(context.TODO(), wf)).To(Succeed())
 	})
 })


### PR DESCRIPTION
The Slurm WLM has the concept of entering teardown state with the help of a "hurry" flag. This flag indicates that any in-progress data transfers must be terminated, or that any transfers not yet begun must be skipped.

It is left to the DWS driver implementation to determine how, and whether, to implement this flag.

Add constraints to the webhook to allow the hurry flag to be used only with teardown state.

Hook up the webhook in the controller tests. We need the reconciler running with the webhook to test things in teardown state.

Hook up tests in dockerfile so they run during the github workflow action, and enable tests in the workflow.

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>