### PR TITLE
RABSW-728: DWS Webhook must reject a workflow with Status.State speci…

### DIFF
--- a/api/v1alpha1/workflow_webhook.go
+++ b/api/v1alpha1/workflow_webhook.go
@@ -82,6 +82,9 @@ func (w *Workflow) ValidateCreate() error {
 	if w.Spec.Hurry == true {
 		return fmt.Errorf("the hurry flag may not be set on creation")
 	}
+	if w.Status.State != "" {
+		return fmt.Errorf("the status state may not be set")
+	}
 
 	return checkDirectives(w, &ValidatingRuleParser{})
 }

--- a/api/v1alpha1/workflow_webhook_test.go
+++ b/api/v1alpha1/workflow_webhook_test.go
@@ -68,4 +68,22 @@ var _ = Describe("Workflow Webhook", func() {
 		Expect(k8sClient.Create(context.TODO(), workflow)).ToNot(Succeed())
 		workflow = nil
 	})
+
+	It("Fails to create workflow with Status.State set", func() {
+		stateStrings := []string{StateProposal.String(),
+			StateSetup.String(),
+			StateDataIn.String(),
+			StatePreRun.String(),
+			StatePostRun.String(),
+			StateDataOut.String(),
+			StateTeardown.String(),
+		}
+
+		for _, s := range stateStrings {
+			workflow.Status.State = s
+			Expect(k8sClient.Create(context.TODO(), workflow)).ToNot(Succeed())
+		}
+		workflow = nil
+	})
+
 })


### PR DESCRIPTION
DWS Webhook must reject a workflow with Status.State specified during create to prevent confusion in the workflow reconciler since it is the only actor that should be setting Status.State.

Signed-off-by: Anthony Floeder <anthony.floeder@hpe.com>