### PR TITLE
RABSW-1016: Return error from status updater

### DIFF
--- a/utils/updater/status_updater.go
+++ b/utils/updater/status_updater.go
@@ -109,5 +109,5 @@ func (updater *statusUpdater[S]) close(ctx context.Context, c clientUpdater, err
 
 	}
 
-	return nil
+	return err
 }

--- a/utils/updater/status_updater_test.go
+++ b/utils/updater/status_updater_test.go
@@ -65,9 +65,10 @@ func (*testWriter) Update(ctx context.Context, obj client.Object, opts ...client
 
 func (*testWriter) Status() client.StatusWriter { return &testStatusWriter{} }
 
-func TestUpdate(t *testing.T)          { testUpdate(t, true, nil) }
-func TestUpdateWithError(t *testing.T) { testUpdate(t, true, errors.Errorf("err")) }
-func TestNoUpdate(t *testing.T)        { testUpdate(t, false, nil) }
+func TestUpdate(t *testing.T)            { testUpdate(t, true, nil) }
+func TestUpdateWithError(t *testing.T)   { testUpdate(t, true, errors.Errorf("err")) }
+func TestNoUpdateWithError(t *testing.T) { testUpdate(t, false, errors.Errorf("err")) }
+func TestNoUpdate(t *testing.T)          { testUpdate(t, false, nil) }
 
 // Test that when a change occurs to the object's status, only the object is updated
 // and not the status
@@ -105,9 +106,10 @@ func (*testStatusWriter) Update(ctx context.Context, obj client.Object, opts ...
 	return nil
 }
 
-func TestStatusUpdate(t *testing.T)          { testStatusUpdate(t, true, nil) }
-func TestStatusUpdateWithError(t *testing.T) { testStatusUpdate(t, true, errors.Errorf("err")) }
-func TestNoStatusUpdate(t *testing.T)        { testStatusUpdate(t, false, nil) }
+func TestStatusUpdate(t *testing.T)            { testStatusUpdate(t, true, nil) }
+func TestStatusUpdateWithError(t *testing.T)   { testStatusUpdate(t, true, errors.Errorf("err")) }
+func TestNoStatusUpdateWithError(t *testing.T) { testStatusUpdate(t, false, errors.Errorf("err")) }
+func TestNoStatusUpdate(t *testing.T)          { testStatusUpdate(t, false, nil) }
 
 // Test when a change occurs to an object's status, only the status fields are
 // updated and not the object.


### PR DESCRIPTION
This commit allows the error value to pass through the status updater if it was set before the defer function.

Signed-off-by: Matt Richerson <matthew.richerson@Matts-MacBook-Pro.local>