### PR TITLE
Rework WorkflowState from int to string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,8 +130,9 @@ container-unit-test: ## Build docker image with the manager and execute unit tes
 	${DOCKER} build -f Dockerfile --label $(IMAGE_TAG_BASE)-$@:$(VERSION)-$@ -t $(IMAGE_TAG_BASE)-$@:$(VERSION) --target testing .
 	${DOCKER} run --rm -t --name $@-nnf-sos  $(IMAGE_TAG_BASE)-$@:$(VERSION)
 
+TESTDIR ?= ./...
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(LOCALBIN))" go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(LOCALBIN))" go test $(TESTDIR) -coverprofile cover.out
 
 ##@ Build
 build-daemon: manifests generate fmt vet ## Build standalone clientMount daemon

--- a/api/v1alpha1/workflow_types.go
+++ b/api/v1alpha1/workflow_types.go
@@ -20,8 +20,6 @@
 package v1alpha1
 
 import (
-	"fmt"
-
 	"github.com/HewlettPackard/dws/utils/updater"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,28 +33,57 @@ const (
 	WorkflowNamespaceLabel = "dws.cray.hpe.com/workflow.namespace"
 )
 
-// WorkflowState is the enumeration of The state of the workflow
-type WorkflowState int
+// WorkflowState is the enumeration of the state of the workflow
+type WorkflowState string
 
-// State enumerations
+// WorkflowState values
 const (
-	StateProposal WorkflowState = iota
-	StateSetup
-	StateDataIn
-	StatePreRun
-	StatePostRun
-	StateDataOut
-	StateTeardown
+	StateProposal WorkflowState = "proposal"
+	StateSetup    WorkflowState = "setup"
+	StateDataIn   WorkflowState = "data_in"
+	StatePreRun   WorkflowState = "pre_run"
+	StatePostRun  WorkflowState = "post_run"
+	StateDataOut  WorkflowState = "data_out"
+	StateTeardown WorkflowState = "teardown"
 )
 
-var workflowStrings = [...]string{
-	"proposal",
-	"setup",
-	"data_in",
-	"pre_run",
-	"post_run",
-	"data_out",
-	"teardown",
+// Next reports the next state after state s
+func (s WorkflowState) next() WorkflowState {
+	switch s {
+	case StateProposal:
+		return StateSetup
+	case StateSetup:
+		return StateDataIn
+	case StateDataIn:
+		return StatePreRun
+	case StatePreRun:
+		return StatePostRun
+	case StatePostRun:
+		return StateDataOut
+	case StateDataOut:
+		return StateTeardown
+	}
+
+	panic(s)
+}
+
+// Last reports whether the state s is the last state
+func (s WorkflowState) last() bool {
+	return s == StateTeardown
+}
+
+// After reports whether the state s is after t
+func (s WorkflowState) after(t WorkflowState) bool {
+
+	for !t.last() {
+		next := t.next()
+		if s == next {
+			return true
+		}
+		t = next
+	}
+
+	return false
 }
 
 // Strings associated with workflow statuses
@@ -69,30 +96,16 @@ const (
 	StatusDriverWait = "DriverWait"
 )
 
-func (s WorkflowState) String() string {
-	return workflowStrings[s]
-}
-
-// GetWorkflowState returns the WorkflowState constant that matches the
-// string value passed in
-func GetWorkflowState(state string) (WorkflowState, error) {
-	for i := StateProposal; i <= StateTeardown; i++ {
-		if i.String() == state {
-			return i, nil
-		}
-	}
-
-	return StateProposal, fmt.Errorf("invalid workflow state '%s'", state)
-}
-
 // WorkflowSpec defines the desired state of Workflow
 type WorkflowSpec struct {
 	// Desired state for the workflow to be in. Unless progressing to the teardown state,
 	// this can only be set to the next state when the current desired state has been achieved.
-	// +kubebuilder:validation:Enum=proposal;setup;data_in;pre_run;post_run;data_out;teardown
-	DesiredState string `json:"desiredState"`
-	WLMID        string `json:"wlmID"`
-	JobID        int    `json:"jobID"`
+	// +kubebuilder:validation:Enum:=proposal;setup;data_in;pre_run;post_run;data_out;teardown
+	// +kubebuilder:validation:Type:=string
+	DesiredState WorkflowState `json:"desiredState"`
+
+	WLMID string `json:"wlmID"`
+	JobID int    `json:"jobID"`
 
 	// UserID specifies the user ID for the workflow. The User ID is used by the various states
 	// in the workflow to ensure the user has permissions to perform certain actions. Used in
@@ -116,12 +129,14 @@ type WorkflowSpec struct {
 
 // WorkflowDriverStatus defines the status information provided by integration drivers.
 type WorkflowDriverStatus struct {
-	DriverID   string `json:"driverID"`
-	TaskID     string `json:"taskID"`
-	DWDIndex   int    `json:"dwdIndex"`
-	WatchState string `json:"watchState"`
-	LastHB     int64  `json:"lastHB"`
-	Completed  bool   `json:"completed"`
+	DriverID string `json:"driverID"`
+	TaskID   string `json:"taskID"`
+	DWDIndex int    `json:"dwdIndex"`
+
+	WatchState WorkflowState `json:"watchState"`
+
+	LastHB    int64 `json:"lastHB"`
+	Completed bool  `json:"completed"`
 
 	// User readable reason.
 	// For the CDS driver, this could be the state of the underlying
@@ -143,8 +158,7 @@ type WorkflowDriverStatus struct {
 type WorkflowStatus struct {
 	// The state the resource is currently transitioning to.
 	// Updated by the controller once started.
-	// +kubebuilder:default:=proposal
-	State string `json:"state"`
+	State WorkflowState `json:"state"`
 
 	// Ready can be 'True', 'False'
 	// Indicates whether State has been reached.

--- a/api/v1alpha1/workflow_webhook.go
+++ b/api/v1alpha1/workflow_webhook.go
@@ -170,10 +170,6 @@ func (w *Workflow) ValidateUpdate(old runtime.Object) error {
 		return field.Invalid(field.NewPath("Spec").Child("DesiredState"), w.Spec.DesiredState, "states cannot be skipped")
 	}
 
-	if oldState.last() {
-		return fmt.Errorf("cannot progress beyond last state")
-	}
-
 	if !oldWorkflow.Status.Ready {
 		return field.Invalid(field.NewPath("Status").Child("State"), oldWorkflow.Status.State, "current desired state not yet achieved")
 	}

--- a/api/v1alpha1/workflow_webhook_test.go
+++ b/api/v1alpha1/workflow_webhook_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Workflow Webhook", func() {
 				Namespace: metav1.NamespaceDefault,
 			},
 			Spec: WorkflowSpec{
-				DesiredState: StateProposal.String(),
+				DesiredState: StateProposal,
 				DWDirectives: []string{},
 			},
 		}
@@ -70,8 +70,8 @@ var _ = Describe("Workflow Webhook", func() {
 	})
 
 	DescribeTable("Workflow created only when Spec.DesiredState is Proposal",
-		func(statusState string, expectSuccess bool) {
-			workflow.Spec.DesiredState = statusState
+		func(desiredState WorkflowState, expectSuccess bool) {
+			workflow.Spec.DesiredState = desiredState
 			if expectSuccess {
 				Expect(k8sClient.Create(context.TODO(), workflow)).Should(Succeed())
 			} else {
@@ -80,27 +80,29 @@ var _ = Describe("Workflow Webhook", func() {
 
 			workflow = nil
 		},
-		Entry("When Spec.DesiredState Proposal", StateProposal.String(), true),
-		Entry("When Spec.DesiredState Setup", StateSetup.String(), false),
-		Entry("When Spec.DesiredState DataIn", StateDataIn.String(), false),
-		Entry("When Spec.DesiredState PreRun", StatePreRun.String(), false),
-		Entry("When Spec.DesiredState PostRun", StatePostRun.String(), false),
-		Entry("When Spec.DesiredState DataOut", StateDataOut.String(), false),
-		Entry("When Spec.DesiredState Teardown", StateTeardown.String(), false),
+		Entry("When Spec.DesiredState Proposal", StateProposal, true),
+		Entry("When Spec.DesiredState Setup", StateSetup, false),
+		Entry("When Spec.DesiredState DataIn", StateDataIn, false),
+		Entry("When Spec.DesiredState PreRun", StatePreRun, false),
+		Entry("When Spec.DesiredState PostRun", StatePostRun, false),
+		Entry("When Spec.DesiredState DataOut", StateDataOut, false),
+		Entry("When Spec.DesiredState Teardown", StateTeardown, false),
 	)
 
 	DescribeTable("Fails to create workflow with Status.State set",
-		func(statusState string) {
+		func(statusState WorkflowState) {
 			workflow.Status.State = statusState
 			Expect(k8sClient.Create(context.TODO(), workflow)).ShouldNot(Succeed())
 			workflow = nil
 		},
-		Entry("When Status.State Proposal", StateProposal.String()),
-		Entry("When Status.State Setup", StateSetup.String()),
-		Entry("When Status.State DataIn", StateDataIn.String()),
-		Entry("When Status.State PreRun", StatePreRun.String()),
-		Entry("When Status.State PostRun", StatePostRun.String()),
-		Entry("When Status.State DataOut", StateDataOut.String()),
-		Entry("When Status.State Teardown", StateTeardown.String()),
+		Entry("When Status.State Proposal", StateProposal),
+		Entry("When Status.State Setup", StateSetup),
+		Entry("When Status.State DataIn", StateDataIn),
+		Entry("When Status.State PreRun", StatePreRun),
+		Entry("When Status.State PostRun", StatePostRun),
+		Entry("When Status.State DataOut", StateDataOut),
+		Entry("When Status.State Teardown", StateTeardown),
 	)
+
+	// Describe Fail transitions
 })

--- a/config/crd/bases/dws.cray.hpe.com_workflows.yaml
+++ b/config/crd/bases/dws.cray.hpe.com_workflows.yaml
@@ -277,6 +277,8 @@ spec:
                     taskID:
                       type: string
                     watchState:
+                      description: WorkflowState is the enumeration of the state of
+                        the workflow
                       type: string
                   required:
                   - completed
@@ -309,7 +311,6 @@ spec:
                 format: date-time
                 type: string
               state:
-                default: proposal
                 description: The state the resource is currently transitioning to.
                   Updated by the controller once started.
                 type: string

--- a/controllers/workflow_controller.go
+++ b/controllers/workflow_controller.go
@@ -133,7 +133,7 @@ func (r *WorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 
 	// Need to set Status.State first because the webhook validates this.
 	if workflow.Status.State != workflow.Spec.DesiredState {
-		log.Info("Workflow state transitioning to " + workflow.Spec.DesiredState)
+		log.Info("Workflow state transitioning", "state", workflow.Spec.DesiredState)
 		workflow.Status.State = workflow.Spec.DesiredState
 		workflow.Status.Ready = ConditionFalse
 		workflow.Status.Status = dwsv1alpha1.StatusDriverWait
@@ -145,7 +145,7 @@ func (r *WorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 	}
 
 	// We must create Computes during proposal state
-	if workflow.Spec.DesiredState == dwsv1alpha1.StateProposal.String() {
+	if workflow.Spec.DesiredState == dwsv1alpha1.StateProposal {
 		computes, err := r.createComputes(ctx, workflow, workflow.Name, log)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -206,7 +206,7 @@ func (r *WorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		ts := metav1.NowMicro()
 		workflow.Status.ReadyChange = &ts
 		workflow.Status.ElapsedTimeLastState = ts.Time.Sub(workflow.Status.DesiredStateChange.Time).Round(time.Microsecond).String()
-		log.Info("Workflow transitioning to ready state " + workflow.Status.State)
+		log.Info("Workflow transitioning to ready", "state", workflow.Status.State)
 	}
 
 	return ctrl.Result{}, nil

--- a/controllers/workflow_controller_test.go
+++ b/controllers/workflow_controller_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Workflow Controller Test", func() {
 				Namespace: corev1.NamespaceDefault,
 			},
 			Spec: dwsv1alpha1.WorkflowSpec{
-				DesiredState: dwsv1alpha1.StateProposal.String(),
+				DesiredState: dwsv1alpha1.StateProposal,
 				WLMID:        "test",
 				JobID:        0,
 				UserID:       0,
@@ -86,7 +86,7 @@ var _ = Describe("Workflow Controller Test", func() {
 			return wf.Status.Status
 		}).Should(Equal(dwsv1alpha1.StatusCompleted))
 
-		wf.Spec.DesiredState = dwsv1alpha1.StateTeardown.String()
+		wf.Spec.DesiredState = dwsv1alpha1.StateTeardown
 		wf.Spec.Hurry = true
 		Expect(k8sClient.Update(context.TODO(), wf)).To(Succeed())
 	})


### PR DESCRIPTION
As WorkflowState is a string in the Workflow, change WorkflowState to a native string type.

A couple of helper functions, `state.last()`, `state.next()`, `state.after(state)` were written to replace the logic that checks for valid transitions.

Signed-off-by: Nate Roiger <nate.roiger@hpe.com>