### PR TITLE
RABSW-1076:DWS: Webhook validation errors should be returning k8s spe…

### DIFF
--- a/api/v1alpha1/workflow_webhook.go
+++ b/api/v1alpha1/workflow_webhook.go
@@ -194,23 +194,23 @@ func validateWorkflowImmutable(wfNew *Workflow, wfOld *Workflow) error {
 
 	specPath := field.NewPath("Spec")
 	if wfNew.Spec.WLMID != wfOld.Spec.WLMID {
-		return field.Forbidden(specPath.Child("WLMID"), "cannot change immutable field WLMID")
+		return field.Forbidden(specPath.Child("WLMID"), "field is immutable")
 	}
 
 	if wfNew.Spec.JobID != wfOld.Spec.JobID {
-		return field.Forbidden(specPath.Child("JobID"), "cannot change immutable field JobID")
+		return field.Forbidden(specPath.Child("JobID"), "field is immutable")
 	}
 
 	if wfNew.Spec.UserID != wfOld.Spec.UserID {
-		return field.Forbidden(specPath.Child("UserID"), "cannot change immutable field UserID")
+		return field.Forbidden(specPath.Child("UserID"), "field is immutable")
 	}
 
 	if wfNew.Spec.GroupID != wfOld.Spec.GroupID {
-		return field.Forbidden(specPath.Child("GroupID"), "cannot change immutable field GroupID")
+		return field.Forbidden(specPath.Child("GroupID"), "field is immutable")
 	}
 
 	if !reflect.DeepEqual(wfNew.Spec.DWDirectives, wfOld.Spec.DWDirectives) {
-		return field.Forbidden(specPath.Child("DWDirectives"), "cannot change immutable field DWDirectives")
+		return field.Forbidden(specPath.Child("DWDirectives"), "field is immutable")
 	}
 
 	return nil

--- a/api/v1alpha1/workflow_webhook_test.go
+++ b/api/v1alpha1/workflow_webhook_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Workflow Webhook", func() {
 
 	It("Fails to create workflow with hurry flag set", func() {
 		workflow.Spec.Hurry = true
-		Expect(k8sClient.Create(context.TODO(), workflow)).ToNot(Succeed())
+		Expect(k8sClient.Create(context.TODO(), workflow)).ShouldNot(Succeed())
 		workflow = nil
 	})
 
@@ -92,7 +92,7 @@ var _ = Describe("Workflow Webhook", func() {
 	DescribeTable("Fails to create workflow with Status.State set",
 		func(statusState string) {
 			workflow.Status.State = statusState
-			Expect(k8sClient.Create(context.TODO(), workflow)).ToNot(Succeed())
+			Expect(k8sClient.Create(context.TODO(), workflow)).ShouldNot(Succeed())
 			workflow = nil
 		},
 		Entry("When Status.State Proposal", StateProposal.String()),


### PR DESCRIPTION
DWS: Webhook validation errors should be returning k8s spec validation error types with detailed violations.

Signed-off-by: Anthony Floeder <anthony.floeder@hpe.com>