### PR TITLE
Change WorkflowState values to conform to the Kubernetes API Convention

### DIFF
--- a/api/v1alpha1/workflow_types.go
+++ b/api/v1alpha1/workflow_types.go
@@ -38,13 +38,13 @@ type WorkflowState string
 
 // WorkflowState values
 const (
-	StateProposal WorkflowState = "proposal"
-	StateSetup    WorkflowState = "setup"
-	StateDataIn   WorkflowState = "data_in"
-	StatePreRun   WorkflowState = "pre_run"
-	StatePostRun  WorkflowState = "post_run"
-	StateDataOut  WorkflowState = "data_out"
-	StateTeardown WorkflowState = "teardown"
+	StateProposal WorkflowState = "Proposal"
+	StateSetup    WorkflowState = "Setup"
+	StateDataIn   WorkflowState = "DataIn"
+	StatePreRun   WorkflowState = "PreRun"
+	StatePostRun  WorkflowState = "PostRun"
+	StateDataOut  WorkflowState = "DataOut"
+	StateTeardown WorkflowState = "Teardown"
 )
 
 // Next reports the next state after state s
@@ -100,7 +100,7 @@ const (
 type WorkflowSpec struct {
 	// Desired state for the workflow to be in. Unless progressing to the teardown state,
 	// this can only be set to the next state when the current desired state has been achieved.
-	// +kubebuilder:validation:Enum:=proposal;setup;data_in;pre_run;post_run;data_out;teardown
+	// +kubebuilder:validation:Enum:=Proposal;Setup;DataIn;PreRun;PostRun;DataOut;Teardown
 	// +kubebuilder:validation:Type:=string
 	DesiredState WorkflowState `json:"desiredState"`
 

--- a/config/crd/bases/dws.cray.hpe.com_workflows.yaml
+++ b/config/crd/bases/dws.cray.hpe.com_workflows.yaml
@@ -76,13 +76,13 @@ spec:
                   to the teardown state, this can only be set to the next state when
                   the current desired state has been achieved.
                 enum:
-                - proposal
-                - setup
-                - data_in
-                - pre_run
-                - post_run
-                - data_out
-                - teardown
+                - Proposal
+                - Setup
+                - DataIn
+                - PreRun
+                - PostRun
+                - DataOut
+                - Teardown
                 type: string
               dwDirectives:
                 description: 'List of #DW strings from a WLM job script'

--- a/config/samples/dws_v1alpha1_workflow.yaml
+++ b/config/samples/dws_v1alpha1_workflow.yaml
@@ -4,7 +4,7 @@ metadata:
   name: dws-workflow-test
 spec:
   # Add fields here
-  desiredState: "proposal"
+  desiredState: Proposal
   dwDirectives:
     - "#DW jobdw type=raw capacity=10TB name=myRawStorage"
   wlmID: "5f239bd8-30db-450b-8c2c-a1a7c8631a1a"


### PR DESCRIPTION
***BREAKING CHANGE***

[API Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#constants) call for constants to use "CamelCase, with an initial uppercase letter"

This also aligns with the Workflow statuses (Pending, Queued, ...)



Signed-off-by: Nate Roiger <nate.roiger@hpe.com>