### PR TITLE
RABSW-1079: Add constants for allocation strategies

### DIFF
--- a/api/v1alpha1/directivebreakdown_types.go
+++ b/api/v1alpha1/directivebreakdown_types.go
@@ -29,6 +29,14 @@ import (
 
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+type AllocationStrategy string
+
+const (
+	AllocatePerCompute    AllocationStrategy = "AllocatePerCompute"
+	AllocateAcrossServers AllocationStrategy = "AllocateAcrossServers"
+	AllocateSingleServer  AllocationStrategy = "AllocateSingleServer"
+)
+
 const (
 	// DirectiveLifetimeJob specifies storage allocated for the lifetime of the job
 	DirectiveLifetimeJob = "job"
@@ -64,8 +72,8 @@ type AllocationSetConstraints struct {
 // StorageAllocationSet defines the details of an allocation set
 type StorageAllocationSet struct {
 	// AllocationStrategy specifies the way to determine the number of allocations of the MinimumCapacity required for this AllocationSet.
-	// +kubebuilder:validation:Enum=AllocatePerCompute;AllocateAcrossServers;AllocateSingleServer;AssignPerCompute;AssignAcrossServers;
-	AllocationStrategy string `json:"allocationStrategy"`
+	// +kubebuilder:validation:Enum=AllocatePerCompute;AllocateAcrossServers;AllocateSingleServer
+	AllocationStrategy AllocationStrategy `json:"allocationStrategy"`
 
 	// MinimumCapacity is the minumum number of bytes required to meet the needs of the filesystem that
 	// will use the storage.

--- a/config/crd/bases/dws.cray.hpe.com_directivebreakdowns.yaml
+++ b/config/crd/bases/dws.cray.hpe.com_directivebreakdowns.yaml
@@ -168,8 +168,6 @@ spec:
                           - AllocatePerCompute
                           - AllocateAcrossServers
                           - AllocateSingleServer
-                          - AssignPerCompute
-                          - AssignAcrossServers
                           type: string
                         constraints:
                           description: Constraint is an additional requirement pertaining


### PR DESCRIPTION
Add a type and constants for the allocation strategies in the directivebreakdown. Clean up some old kubebuilder validation too.

Signed-off-by: Matt Richerson <matthew.richerson@Matts-MacBook-Pro.local>