### PR TITLE
Adding cluster name to kind-push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,8 +150,9 @@ docker-build: manifests generate fmt vet ## Build docker image with the manager.
 docker-push: ## Push docker image with the manager.
 	${DOCKER} push ${IMG}
 
+KIND_CLUSTER ?= "kind"
 kind-push: ## Push docker image to kind
-	kind load docker-image --nodes `kubectl get node -l cray.wlm.manager=true --no-headers -o custom-columns=":metadata.name" | paste -d, -s -` ${IMG}
+	kind load docker-image --name $(KIND_CLUSTER) --nodes `kubectl get node -l cray.wlm.manager=true --no-headers -o custom-columns=":metadata.name" | paste -d, -s -` ${IMG}
 
 ##@ Deployment
 


### PR DESCRIPTION
Signed-off-by: Nathan Lee <nathan.lee@hpe.com>

dws-slurm-bb-plugin will also use Kind for integration testing. Adding support for named clusters will help prevent conflicts when dws and dws-slurm-bb-plugin tests are run on the same machine.