### PR TITLE
Support CSM.

### DIFF
--- a/config/csm/kustomization.yaml
+++ b/config/csm/kustomization.yaml
@@ -1,0 +1,37 @@
+# Use DP0 (real hardware) for the base.
+bases:
+- ../dp0
+
+# Adjustments for CSM 0.9.3:
+#  - The kube-rbac-proxy will be in the local container registry.
+#  - The cert-manager is ancient, at v0.14.1.
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/1/image
+        value: registry.local/kube-rbac-proxy:v0.13.0
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: dws-operator-controller-manager
+  - patch: |-
+      - op: replace
+        path: /apiVersion
+        value: cert-manager.io/v1alpha3
+    target:
+      group: cert-manager.io
+      version: v1
+      kind: Certificate
+      name: dws-operator-serving-cert
+  - patch: |-
+      - op: replace
+        path: /apiVersion
+        value: cert-manager.io/v1alpha3
+    target:
+      group: cert-manager.io
+      version: v1
+      kind: Issuer
+      name: dws-operator-selfsigned-issuer
+
+


### PR DESCRIPTION
Use the DP0 overlay (real hardware) for the config base.  CSM currently uses an ancient cert-manager at v0.14.1, so set the apiVersion back to v1alpha3 to accomodate that.

The CSM systems we are testing on do not have access to gcr.io, so we have to use skopeo to copy kube-rbac-proxy into the CSM system's own container registry.  Patch the Deployment to find it in this location.

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>