### PR TITLE
Install the workflow-editor-role

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - service_account.yaml
 - role.yaml
 - role_binding.yaml
+- workflow_editor_role.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
 # Comment the following 4 lines if you want to disable


### PR DESCRIPTION
Install the workflow-editor-role, so that apps like Slurm can make a binding to use it to create and manipulate workflow resources.

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>