### PR TITLE
Use the os.Hostname() value in absence of a supplied '--node-name' ar…

### DIFF
--- a/mount-daemon/main.go
+++ b/mount-daemon/main.go
@@ -115,7 +115,6 @@ type options struct {
 	host      string
 	port      string
 	name      string
-	nodeName  string
 	tokenFile string
 	certFile  string
 	mock      bool
@@ -154,6 +153,15 @@ func createManager(opts *options) (*managerConfig, error) {
 
 	var config *rest.Config
 	var err error
+
+	if len(opts.name) == 0 {
+		setupLog.Info("Using system hostname")
+
+		opts.name, err = os.Hostname()
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	if len(opts.host) == 0 && len(opts.port) == 0 {
 		setupLog.Info("Using kubeconfig rest configuration")


### PR DESCRIPTION
Use the os.Hostname() value in absence of a supplied '--node-name' argument or env variable

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>