### PR TITLE
Remove Rabbit enforcement on the StorageNode.Type

### DIFF
--- a/api/v1alpha1/systemconfiguration_types.go
+++ b/api/v1alpha1/systemconfiguration_types.go
@@ -42,7 +42,6 @@ type SystemConfigurationComputeNodeReference struct {
 // SystemConfigurationStorageNode describes a storage node in the system
 type SystemConfigurationStorageNode struct {
 	// Type is the type of server
-	// +kubebuilder:validation:Enum=Rabbit
 	Type string `json:"type"`
 
 	// Name of the server node

--- a/config/crd/bases/dws.cray.hpe.com_systemconfigurations.yaml
+++ b/config/crd/bases/dws.cray.hpe.com_systemconfigurations.yaml
@@ -88,8 +88,6 @@ spec:
                       type: string
                     type:
                       description: Type is the type of server
-                      enum:
-                      - Rabbit
                       type: string
                   required:
                   - name


### PR DESCRIPTION
… dws can use them

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>