### PR TITLE
On the master branch, allow git-version-gen to use the SHA for .version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 	$(KUSTOMIZE) build config/${OVERLAY} | kubectl delete --ignore-not-found -f -
 
 .version: ## Uses the git-version-gen script to generate a tag version
-	./git-version-gen > .version
+	./git-version-gen --fallback `git rev-parse HEAD` > .version
 
 clean:
 	rm -f .version

--- a/git-version-gen
+++ b/git-version-gen
@@ -166,7 +166,7 @@ then
     # Remove the "g" to save a byte.
     v=`echo "$v" | sed 's/-\([^-]*\)-g\([^-]*\)$/.\1-\2/'`;
     v_from_git=1
-elif test "x$fallback" = x || git --version >/dev/null 2>&1; then
+elif test "x$fallback" = x; then
     v=UNKNOWN
 else
     v=$fallback


### PR DESCRIPTION
On the master branch, allow git-version-gen to use the SHA as the value for the .version file, because there are no tags on the master branch for it to use for that purpose.

This allows nnf-deploy to succeed when using this master branch in a KIND environment.

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>