### PR TITLE
Add an app label on the DWS pod.

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,6 +21,7 @@ spec:
     metadata:
       labels:
         control-plane: controller-manager
+        app: dws
     spec:
       nodeSelector:
         cray.wlm.manager: "true"


### PR DESCRIPTION
Add a label of app=dws on the DWS pod to make it easier to work with the pod without having to look it up.

Examples:
$ kubectl logs -n dws-operator-system -l app=dws -c manager 
$ kubectl get pod -n dws-operator-system -l app=dws -o jsonpath='{.items[].metadata.name}'

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>