### PR TITLE
Workflow State kubebuilder validation enum _type_ (not field)

### DIFF
--- a/api/v1alpha1/workflow_types.go
+++ b/api/v1alpha1/workflow_types.go
@@ -34,6 +34,7 @@ const (
 )
 
 // WorkflowState is the enumeration of the state of the workflow
+// +kubebuilder:validation:Enum:=Proposal;Setup;DataIn;PreRun;PostRun;DataOut;Teardown
 type WorkflowState string
 
 // WorkflowState values
@@ -100,8 +101,6 @@ const (
 type WorkflowSpec struct {
 	// Desired state for the workflow to be in. Unless progressing to the teardown state,
 	// this can only be set to the next state when the current desired state has been achieved.
-	// +kubebuilder:validation:Enum:=Proposal;Setup;DataIn;PreRun;PostRun;DataOut;Teardown
-	// +kubebuilder:validation:Type:=string
 	DesiredState WorkflowState `json:"desiredState"`
 
 	WLMID string `json:"wlmID"`

--- a/api/v1alpha1/workflow_types.go
+++ b/api/v1alpha1/workflow_types.go
@@ -158,7 +158,7 @@ type WorkflowDriverStatus struct {
 type WorkflowStatus struct {
 	// The state the resource is currently transitioning to.
 	// Updated by the controller once started.
-	State WorkflowState `json:"state"`
+	State WorkflowState `json:"state,omitempty"`
 
 	// Ready can be 'True', 'False'
 	// Indicates whether State has been reached.

--- a/api/v1alpha1/workflow_webhook.go
+++ b/api/v1alpha1/workflow_webhook.go
@@ -87,7 +87,7 @@ func (w *Workflow) ValidateCreate() error {
 		return field.Forbidden(specPath.Child("Hurry"), "the hurry flag may not be set on creation")
 	}
 	if w.Status.State != "" {
-		return field.Forbidden(field.NewPath("Status").Child("State"), "the status state may not be set")
+		return field.Forbidden(field.NewPath("Status").Child("State"), "the status state may not be set on creation")
 	}
 
 	return checkDirectives(w, &ValidatingRuleParser{})

--- a/config/crd/bases/dws.cray.hpe.com_workflows.yaml
+++ b/config/crd/bases/dws.cray.hpe.com_workflows.yaml
@@ -281,6 +281,14 @@ spec:
                     watchState:
                       description: WorkflowState is the enumeration of the state of
                         the workflow
+                      enum:
+                      - Proposal
+                      - Setup
+                      - DataIn
+                      - PreRun
+                      - PostRun
+                      - DataOut
+                      - Teardown
                       type: string
                   required:
                   - completed
@@ -317,6 +325,14 @@ spec:
               state:
                 description: The state the resource is currently transitioning to.
                   Updated by the controller once started.
+                enum:
+                - Proposal
+                - Setup
+                - DataIn
+                - PreRun
+                - PostRun
+                - DataOut
+                - Teardown
                 type: string
               status:
                 description: User readable reason and status message

--- a/config/crd/bases/dws.cray.hpe.com_workflows.yaml
+++ b/config/crd/bases/dws.cray.hpe.com_workflows.yaml
@@ -343,7 +343,6 @@ spec:
                 type: string
             required:
             - ready
-            - state
             type: object
         type: object
     served: true


### PR DESCRIPTION
Place the kubebuilder validation enum on the WorkflowState type and not the field

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>