### PR TITLE
Update vscode launch target so reference local kubebuilder assets

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,11 +13,10 @@
             "args": [
                 "-ginkgo.v",
                 "-ginkgo.progress",
-                "-ginkgo.failFast",
+                "-ginkgo.fail-fast",
             ],
             "env": {
-                //"KUBEBUILDER_ASSETS": "/Users/roiger/Library/Application Support/io.kubebuilder.envtest/k8s/1.25.0-darwin-amd64",
-                "KUBEBUILDER_ASSETS": "YOUR LOCATION OF ENVTEST (run './bin/setup-envtest use' and locate the folder)",
+                "KUBEBUILDER_ASSETS": "${workspaceFolder}/bin/k8s/1.25.0-darwin-amd64",
                 "GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT": "10m",
                 "GOMEGA_DEFAULT_EVENTUALLY_POLLING_INTERVAL": "100ms",
             },


### PR DESCRIPTION
For those who use vscode, I updated the test target so it references the correct kubebuilder assets directory. This will work for us x86 folks but you ARM folks are on your own.

Also, ginkgo's "failFast" has been replaced by "fail-fast" so I silence that deprecation message

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>