### PR TITLE
Panic when validation webhook is run on newly created workflow

### DIFF
--- a/api/v1alpha1/workflow_types.go
+++ b/api/v1alpha1/workflow_types.go
@@ -51,6 +51,8 @@ const (
 // Next reports the next state after state s
 func (s WorkflowState) next() WorkflowState {
 	switch s {
+	case "":
+		return StateProposal
 	case StateProposal:
 		return StateSetup
 	case StateSetup:


### PR DESCRIPTION
On a newly created workflow the status.State is an empty string, so when the validation webhook runs the oldState.next() will panic since this is an unhandled case. This doesn't actually cause any problems besides noise in the logs, but I'm squashing it anyways.

Signed-off-by: Nate Thornton <nate.thornton@hpe.com>