### PR TITLE
Allow builds on all branches.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,8 +3,7 @@ name: Docker build and push
 on:
   push:
     branches:
-      - 'master'
-      - 'releases/v*'
+      - '*'
     tags:
       - 'v*'
   pull_request:
@@ -27,6 +26,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: "Build context"
+      run: |
+        echo "ref is ${{ github.ref }}"
+        echo "ref_type is ${{ github.ref_type }}"
+
     - name: "Checkout repository"
       id: checkout_repo
       uses: actions/checkout@v3

--- a/.github/workflows/rpm_build.yml
+++ b/.github/workflows/rpm_build.yml
@@ -2,7 +2,7 @@ name: RPM Build
 on: push
 
 jobs:
-  build:
+  rpm_build:
     runs-on: ubuntu-latest
     container:
       image: centos:8

--- a/.github/workflows/verify_tag.yml
+++ b/.github/workflows/verify_tag.yml
@@ -7,13 +7,15 @@ on:
     tags:
       - "v*"
 
-env:
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
-  build:
+  verify_tag:
     runs-on: ubuntu-latest
     steps:
+      - name: "Verify context"
+        run: |
+          echo "ref is ${{ github.ref }}"
+          echo "ref_type is ${{ github.ref_type }}"
+
       - uses: actions/checkout@v3
         # actions/checkout@v3 breaks annotated tags by converting them into
         # lightweight tags, so we need to force fetch the tag again


### PR DESCRIPTION
Loosen the branch filter for pushes.
Print some event context, for future debugging.
Remove an unused variable from verify_tag.
Rename some jobs to give them unique names, to help with debugging.

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>