### PR TITLE
RABSW-1128: Only fake out clientmounts on compute nodes in kind

### DIFF
--- a/controllers/clientmount_controller.go
+++ b/controllers/clientmount_controller.go
@@ -21,7 +21,6 @@ package controllers
 
 import (
 	"context"
-	"os"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -124,12 +123,8 @@ func filterByNonRabbitNamespacePrefixForTest() predicate.Predicate {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ClientMountReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	builder := ctrl.NewControllerManagedBy(mgr).
-		For(&dwsv1alpha1.ClientMount{})
-
-	if _, found := os.LookupEnv("NNF_TEST_ENVIRONMENT"); found {
-		builder = builder.WithEventFilter(filterByNonRabbitNamespacePrefixForTest())
-	}
-
-	return builder.Complete(r)
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&dwsv1alpha1.ClientMount{}).
+		WithEventFilter(filterByNonRabbitNamespacePrefixForTest()).
+		Complete(r)
 }

--- a/controllers/clientmount_controller.go
+++ b/controllers/clientmount_controller.go
@@ -115,7 +115,7 @@ func (r *ClientMountReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	return ctrl.Result{}, nil
 }
 
-func filterByNonRabbitNamespacePrefixForTest() predicate.Predicate {
+func filterByNonRabbitNamespacePrefix() predicate.Predicate {
 	return predicate.NewPredicateFuncs(func(object client.Object) bool {
 		return !strings.HasPrefix(object.GetNamespace(), "rabbit")
 	})
@@ -125,6 +125,6 @@ func filterByNonRabbitNamespacePrefixForTest() predicate.Predicate {
 func (r *ClientMountReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&dwsv1alpha1.ClientMount{}).
-		WithEventFilter(filterByNonRabbitNamespacePrefixForTest()).
+		WithEventFilter(filterByNonRabbitNamespacePrefix()).
 		Complete(r)
 }


### PR DESCRIPTION
When running in kind, the rabbit nodes have a separate clientmount controller in the nnf-sos code that handles fake Rabbit mounts.

Signed-off-by: Matt Richerson <matthew.richerson@hpe.com>