### PR TITLE
RABSW-1140: Requeue after initializing status section in clientmountd

### DIFF
--- a/mount-daemon/controllers/clientmount_controller.go
+++ b/mount-daemon/controllers/clientmount_controller.go
@@ -107,7 +107,7 @@ func (r *ClientMountReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			clientMount.Status.Mounts[i].Ready = false
 		}
 
-		return ctrl.Result{}, nil
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	// Add finalizer if it doesn't exist


### PR DESCRIPTION
The Status.Update() call won't generate an event, so a requeue is needed to make sure we continue reconciling the ClientMount.

Signed-off-by: Matt Richerson <matthew.richerson@hpe.com>