### PR TITLE
RABSW-1054: Add timeout for commands run by clientmountd

### DIFF
--- a/mount-daemon/controllers/clientmount_controller.go
+++ b/mount-daemon/controllers/clientmount_controller.go
@@ -45,7 +45,7 @@ import (
 type ClientMountReconciler struct {
 	client.Client
 	Mock    bool
-	Timeout uint
+	Timeout time.Duration
 	Log     logr.Logger
 	Scheme  *runtime.Scheme
 }
@@ -428,7 +428,7 @@ func (r *ClientMountReconciler) run(c string) (string, error) {
 	ctx := context.Background()
 	if r.Timeout > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(context.Background(), time.Duration(r.Timeout)*time.Second)
+		ctx, cancel = context.WithTimeout(context.Background(), r.Timeout)
 		defer cancel()
 	}
 

--- a/mount-daemon/main.go
+++ b/mount-daemon/main.go
@@ -28,6 +28,7 @@ import (
 	"os/signal"
 	"runtime"
 	"syscall"
+	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -109,7 +110,7 @@ type managerConfig struct {
 	config    *rest.Config
 	namespace string
 	mock      bool
-	timeout   uint
+	timeout   time.Duration
 }
 
 type options struct {
@@ -119,7 +120,7 @@ type options struct {
 	tokenFile string
 	certFile  string
 	mock      bool
-	timeout   uint
+	timeout   time.Duration
 }
 
 func getOptions() *options {
@@ -130,7 +131,7 @@ func getOptions() *options {
 		tokenFile: os.Getenv("DWS_CLIENT_MOUNT_SERVICE_TOKEN_FILE"),
 		certFile:  os.Getenv("DWS_CLIENT_MOUNT_SERVICE_CERT_FILE"),
 		mock:      false,
-		timeout:   60,
+		timeout:   time.Minute,
 	}
 
 	flag.StringVar(&opts.host, "kubernetes-service-host", opts.host, "Kubernetes service host address")
@@ -139,7 +140,7 @@ func getOptions() *options {
 	flag.StringVar(&opts.tokenFile, "service-token-file", opts.tokenFile, "Path to the DWS client mount service token")
 	flag.StringVar(&opts.certFile, "service-cert-file", opts.certFile, "Path to the DWS client mount service certificate")
 	flag.BoolVar(&opts.mock, "mock", opts.mock, "Run in mock mode where no client mount operations take place")
-	flag.UintVar(&opts.timeout, "command-timeout", opts.timeout, "Timeout value in seconds before subcommands are killed")
+	flag.DurationVar(&opts.timeout, "command-timeout", opts.timeout, "Timeout value before subcommands are killed")
 
 	zapOptions := zap.Options{
 		Development: true,


### PR DESCRIPTION
Add a 60 second (configurable) timeout to any commands run by clientmountd. The command is killed so that an error can be logged and recorded in the workflow.

Signed-off-by: Matt Richerson <matthew.richerson@hpe.com>