### PR TITLE
Add commit and version string to clientmountd

### DIFF
--- a/.github/workflows/rpm_build.yml
+++ b/.github/workflows/rpm_build.yml
@@ -22,6 +22,7 @@ jobs:
           dnf install -y rpm-build rpmdevtools git make
           dnf module -y install go-toolset 
           rpmdev-setuptree
+          echo $GITHUB_SHA | cut -c1-8 > .commit
           tar -czf /github/home/rpmbuild/SOURCES/dws-clientmount-1.0.tar.gz --transform 's,^,dws-clientmount-1.0/,' .
       - name: build rpms
         run: rpmbuild -ba clientmount.spec

--- a/Makefile
+++ b/Makefile
@@ -129,8 +129,10 @@ test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(LOCALBIN))" go test $(TESTDIR) -coverprofile cover.out
 
 ##@ Build
+build-daemon: COMMIT_HASH?=$(shell git rev-parse --short HEAD)
+build-daemon: PACKAGE = github.com/HewlettPackard/dws/mount-daemon/version
 build-daemon: manifests generate fmt vet ## Build standalone clientMount daemon
-	GOOS=linux GOARCH=amd64 go build -o bin/clientmountd mount-daemon/main.go
+	GOOS=linux GOARCH=amd64 go build -ldflags="-X '$(PACKAGE).commitHash=$(COMMIT_HASH)'" -o bin/clientmountd mount-daemon/main.go
 
 build: manifests generate fmt vet ## Build manager binary.
 	go build -o bin/manager main.go

--- a/clientmount.spec
+++ b/clientmount.spec
@@ -22,7 +22,7 @@ data workflow service
 %setup -q
 
 %build
-make build-daemon
+COMMIT_HASH=$(cat .commit) make build-daemon
 
 %install
 mkdir -p %{buildroot}/usr/bin/

--- a/mount-daemon/main.go
+++ b/mount-daemon/main.go
@@ -44,6 +44,7 @@ import (
 
 	dwsv1alpha1 "github.com/HewlettPackard/dws/api/v1alpha1"
 	"github.com/HewlettPackard/dws/mount-daemon/controllers"
+	"github.com/HewlettPackard/dws/mount-daemon/version"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -86,6 +87,8 @@ func (service *Service) Manage() (string, error) {
 	}
 
 	opts := getOptions()
+
+	setupLog.Info("Client Mount Daemon", "Version", version.BuildVersion())
 
 	config, err := createManager(opts)
 	if err != nil {

--- a/mount-daemon/version/version.go
+++ b/mount-daemon/version/version.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Hewlett Packard Enterprise Development LP
+ * Other additional copyright holders may be indicated within.
+ *
+ * The entirety of this work is licensed under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package version
+
+// The current clientmountd version string.
+var (
+	// Version contains the current version of the clientmount daemon.
+	version = "v0.0.1"
+
+	// Commit Hash is the shortened git commit of the clientmount daemon. This value is patched
+	// if using the "build-daemon" make target, and "unknown" otherwise.
+	commitHash = "unknown"
+)
+
+func BuildVersion() string { return version + "-" + commitHash }


### PR DESCRIPTION
Print a commit hash and version string when clientmountd starts. This uses the same mechanism as nnf-dm.