### PR TITLE
RABSW-1150: Add ServiceAccount for clientmountd

### DIFF
--- a/config/rbac/clientmount_role.yaml
+++ b/config/rbac/clientmount_role.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: clientmount-role
+rules:
+- apiGroups:
+  - dws.cray.hpe.com
+  resources:
+  - clientmounts
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - dws.cray.hpe.com
+  resources:
+  - clientmounts/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - dws.cray.hpe.com
+  resources:
+  - clientmounts/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/config/rbac/clientmount_role_binding.yaml
+++ b/config/rbac/clientmount_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: clientmount-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: clientmount-role
+subjects:
+- kind: ServiceAccount
+  name: clientmount
+  namespace: system

--- a/config/rbac/clientmount_service_account.yaml
+++ b/config/rbac/clientmount_service_account.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: clientmount
+  namespace: system
+---
+# As of Kubernetes 1.24, ServiceAccount tokens are no longer automatically
+# generated. Instead, manually create the secret and the token key in the
+# data field will be automatically set.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: clientmount
+  namespace: system
+  annotations:
+    kubernetes.io/service-account.name: clientmount
+    kubernetes.io/service-account.namespace: system
+type: kubernetes.io/service-account-token

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -7,6 +7,9 @@ resources:
 - service_account.yaml
 - role.yaml
 - role_binding.yaml
+- clientmount_service_account.yaml
+- clientmount_role.yaml
+- clientmount_role_binding.yaml
 - workflow_editor_role.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml


### PR DESCRIPTION
Add a ServiceAccount for clientmountd that only allows read and write access to the ClientMount resource.