### PR TITLE
Use the live k8s client object in suite_test.go.

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -79,6 +79,10 @@ var _ = BeforeSuite(func() {
 
 	//+kubebuilder:scaffold:scheme
 
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
 	// start webhook server using Manager
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
@@ -100,9 +104,6 @@ var _ = BeforeSuite(func() {
 		Scheme: testEnv.Scheme,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
-
-	k8sClient = k8sManager.GetClient()
-	Expect(k8sClient).ToNot(BeNil())
 
 	go func() {
 		defer GinkgoRecover()


### PR DESCRIPTION
In the kubebuilder book:
https://book.kubebuilder.io/cronjob-tutorial/writing-tests.html It explains that we should be using the "live" k8s client rather than the one from the manager:

"Note that we set up both a “live” k8s client and a separate client from the manager. This is because when making assertions in tests, you generally want to assert against the live state of the API server. If you use the client from the manager (k8sManager.GetClient), you’d end up asserting against the contents of the cache instead, which is slower and can introduce flakiness into your tests."