### PR TITLE
Update IMAGE_TAG_BASE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
 # cray.hpe.com/dws-operator-bundle:$VERSION and cray.hpe.com/dws-operator-catalog:$VERSION.
-IMAGE_TAG_BASE ?= ghcr.io/hewlettpackard/dws-operator
+IMAGE_TAG_BASE ?= ghcr.io/hewlettpackard/dws
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)


### PR DESCRIPTION
The base should be "dws", to match the images that are built from our github workflows.