### PR TITLE
Let all tests recognize ginkgo args

### DIFF
--- a/utils/dwdparse/dwdparse_test.go
+++ b/utils/dwdparse/dwdparse_test.go
@@ -20,6 +20,7 @@
 package dwdparse
 
 import (
+	. "github.com/onsi/ginkgo/v2"
 	"testing"
 )
 
@@ -450,3 +451,7 @@ func TestKeyMalformedRegexp(t *testing.T) {
 
 	test(t, rules, tests)
 }
+
+// Just touch ginkgo, so it's here to interpret any ginkgo args from
+// "make test", so that doesn't fail on this test file.
+var _ = BeforeSuite(func() {})

--- a/utils/updater/status_updater_test.go
+++ b/utils/updater/status_updater_test.go
@@ -22,6 +22,8 @@ import (
 	"context"
 	"testing"
 
+	. "github.com/onsi/ginkgo/v2"
+
 	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -129,3 +131,7 @@ func testStatusUpdate(t *testing.T, changed bool, err error) {
 		t.Errorf("Test status not updated")
 	}
 }
+
+// Just touch ginkgo, so it's here to interpret any ginkgo args from
+// "make test", so that doesn't fail on this test file.
+var _ = BeforeSuite(func() {})


### PR DESCRIPTION
When adding a "-ginkgo.foo" arg to the "go test" command in the "make test" target, two tests were failing because they didn't recognize ginkgo args.

Now a ginkgo arg can be added to that make target, like this:
   go test $(TESTDIR) -coverprofile cover.out -ginkgo.v