### PR TITLE
github-35: Rescan NVMe devices if namespaces aren't found on compute …

### DIFF
--- a/mount-daemon/controllers/clientmount_controller.go
+++ b/mount-daemon/controllers/clientmount_controller.go
@@ -22,9 +22,11 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -380,10 +382,36 @@ func (r *ClientMountReconciler) configureLVMDevice(lvm *dwsv1alpha1.ClientMountD
 		return nil
 	}
 
-	err = dwsv1alpha1.NewResourceError(fmt.Sprintf("Could not find VG/LV pair %s/%s", lvm.VolumeGroup, lvm.LogicalVolume)+": "+output, nil).WithFatal()
+	if err := r.rescanNVMeDevices(); err != nil {
+		return err
+	}
+
+	err = dwsv1alpha1.NewResourceError(fmt.Sprintf("Could not find VG/LV pair %s/%s", lvm.VolumeGroup, lvm.LogicalVolume)+": "+output, nil)
 	r.Log.Info(err.Error())
 
 	return err
+}
+
+func (r *ClientMountReconciler) rescanNVMeDevices() error {
+	devices, err := ioutil.ReadDir("/dev/")
+	if err != nil {
+		return err
+	}
+
+	nvmeDevices := []string{}
+	for _, device := range devices {
+		match, _ := regexp.MatchString("nvme[0-9]+$", device.Name())
+		if match {
+			nvmeDevices = append(nvmeDevices, "/dev/"+device.Name())
+		}
+	}
+
+	output, err := r.run("nvme ns-rescan " + strings.Join(nvmeDevices, " "))
+	if err != nil {
+		return dwsv1alpha1.NewResourceError(output, err).WithUserMessage("Could not rescan NVMe devices").WithFatal()
+	}
+
+	return nil
 }
 
 // checkMount checks whether a file system is mounted at the path specified in "mountPath"

--- a/mount-daemon/controllers/clientmount_controller.go
+++ b/mount-daemon/controllers/clientmount_controller.go
@@ -399,15 +399,14 @@ func (r *ClientMountReconciler) rescanNVMeDevices() error {
 	}
 
 	nvmeDevices := []string{}
+	nvmeRegex, _ := regexp.Compile("nvme[0-9]+$")
 	for _, device := range devices {
-		match, _ := regexp.MatchString("nvme[0-9]+$", device.Name())
-		if match {
+		if match := nvmeRegex.MatchString(device.Name()); match {
 			nvmeDevices = append(nvmeDevices, "/dev/"+device.Name())
 		}
 	}
 
-	output, err := r.run("nvme ns-rescan " + strings.Join(nvmeDevices, " "))
-	if err != nil {
+	if output, err := r.run("nvme ns-rescan " + strings.Join(nvmeDevices, " ")); err != nil {
 		return dwsv1alpha1.NewResourceError(output, err).WithUserMessage("Could not rescan NVMe devices").WithFatal()
 	}
 


### PR DESCRIPTION
…node

If the namespaces aren't found on the compute node, then clientmountd issues a "nvme ns-rescan" on all the nvme devices.