### PR TITLE
Create clientmountd's version from git-version-gen

### DIFF
--- a/.github/workflows/rpm_build.yml
+++ b/.github/workflows/rpm_build.yml
@@ -1,9 +1,36 @@
 name: RPM Build
-on: push
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - 'master'
+      - 'releases/v*'
 
 jobs:
+  repo_version:
+    runs-on: ubuntu-latest
+    outputs:
+      version_output: ${{ steps.step1.outputs.version }}
+    steps:
+      - name: Verify context
+        run: |
+          echo "ref is ${{ github.ref }}"
+          echo "ref_type is ${{ github.ref_type }}"
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Get Version
+        id: step1
+        run: echo "version=$(./git-version-gen)" >> $GITHUB_OUTPUT
+
   rpm_build:
     runs-on: ubuntu-latest
+    needs: repo_version
     container:
       image: centos:8
       env:
@@ -12,9 +39,20 @@ jobs:
         - 80
       options: --cpus 1
     steps:
+      - name: "Build context"
+        env:
+          VERSION_OUTPUT: ${{ needs.repo_version.outputs.version_output }}
+        run: |
+          echo "ref is ${{ github.ref }}"
+          echo "ref_type is ${{ github.ref_type }}"
+          echo "head.sha is ${{ github.event.pull_request.head.sha }}"
+          echo "git-version-gen is $VERSION_OUTPUT"
+
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: environment setup
+        env:
+          VERSION_OUTPUT: ${{ needs.repo_version.outputs.version_output }}
         run: |
           dnf -y --disablerepo '*' --enablerepo=extras swap centos-linux-repos centos-stream-repos
           dnf -y distro-sync
@@ -22,7 +60,8 @@ jobs:
           dnf install -y rpm-build rpmdevtools git make
           dnf module -y install go-toolset 
           rpmdev-setuptree
-          make .version
+          echo $VERSION_OUTPUT > .rpmversion
+          cat .rpmversion
           tar -czf /github/home/rpmbuild/SOURCES/dws-clientmount-1.0.tar.gz --transform 's,^,dws-clientmount-1.0/,' .
       - name: build rpms
         run: rpmbuild -ba clientmount.spec

--- a/.github/workflows/rpm_build.yml
+++ b/.github/workflows/rpm_build.yml
@@ -22,7 +22,7 @@ jobs:
           dnf install -y rpm-build rpmdevtools git make
           dnf module -y install go-toolset 
           rpmdev-setuptree
-          echo $GITHUB_SHA | cut -c1-8 > .commit
+          make .version
           tar -czf /github/home/rpmbuild/SOURCES/dws-clientmount-1.0.tar.gz --transform 's,^,dws-clientmount-1.0/,' .
       - name: build rpms
         run: rpmbuild -ba clientmount.spec

--- a/Makefile
+++ b/Makefile
@@ -129,10 +129,11 @@ test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(LOCALBIN))" go test $(TESTDIR) -coverprofile cover.out
 
 ##@ Build
-build-daemon: COMMIT_HASH?=$(shell git rev-parse --short HEAD)
+build-daemon: VERSION ?= $(shell cat .version)
+build-daemon: .version
 build-daemon: PACKAGE = github.com/HewlettPackard/dws/mount-daemon/version
 build-daemon: manifests generate fmt vet ## Build standalone clientMount daemon
-	GOOS=linux GOARCH=amd64 go build -ldflags="-X '$(PACKAGE).commitHash=$(COMMIT_HASH)'" -o bin/clientmountd mount-daemon/main.go
+	GOOS=linux GOARCH=amd64 go build -ldflags="-X '$(PACKAGE).version=$(VERSION)'" -o bin/clientmountd mount-daemon/main.go
 
 build: manifests generate fmt vet ## Build manager binary.
 	go build -o bin/manager main.go

--- a/Makefile
+++ b/Makefile
@@ -129,11 +129,10 @@ test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(LOCALBIN))" go test $(TESTDIR) -coverprofile cover.out
 
 ##@ Build
-build-daemon: VERSION ?= $(shell cat .version)
-build-daemon: .version
+build-daemon: RPM_VERSION ?= $(shell ./git-version-gen)
 build-daemon: PACKAGE = github.com/HewlettPackard/dws/mount-daemon/version
 build-daemon: manifests generate fmt vet ## Build standalone clientMount daemon
-	GOOS=linux GOARCH=amd64 go build -ldflags="-X '$(PACKAGE).version=$(VERSION)'" -o bin/clientmountd mount-daemon/main.go
+	GOOS=linux GOARCH=amd64 go build -ldflags="-X '$(PACKAGE).version=$(RPM_VERSION)'" -o bin/clientmountd mount-daemon/main.go
 
 build: manifests generate fmt vet ## Build manager binary.
 	go build -o bin/manager main.go

--- a/clientmount.spec
+++ b/clientmount.spec
@@ -22,7 +22,7 @@ data workflow service
 %setup -q
 
 %build
-VERSION=$(cat .version) make build-daemon
+RPM_VERSION=$(cat .rpmversion) make build-daemon
 
 %install
 mkdir -p %{buildroot}/usr/bin/

--- a/clientmount.spec
+++ b/clientmount.spec
@@ -22,7 +22,7 @@ data workflow service
 %setup -q
 
 %build
-COMMIT_HASH=$(cat .commit) make build-daemon
+make build-daemon
 
 %install
 mkdir -p %{buildroot}/usr/bin/

--- a/clientmount.spec
+++ b/clientmount.spec
@@ -22,7 +22,7 @@ data workflow service
 %setup -q
 
 %build
-make build-daemon
+VERSION=$(cat .version) make build-daemon
 
 %install
 mkdir -p %{buildroot}/usr/bin/

--- a/mount-daemon/main.go
+++ b/mount-daemon/main.go
@@ -251,6 +251,12 @@ func startManager(config *managerConfig) {
 }
 
 func main() {
+
+	if len(os.Args) > 1 && os.Args[1] == "version" {
+		fmt.Println("Version", version.BuildVersion())
+		os.Exit(0)
+	}
+
 	kindFn := func() daemon.Kind {
 		if runtime.GOOS == "darwin" {
 			return daemon.UserAgent

--- a/mount-daemon/version/version.go
+++ b/mount-daemon/version/version.go
@@ -22,11 +22,9 @@ package version
 // The current clientmountd version string.
 var (
 	// Version contains the current version of the clientmount daemon.
-	version = "v0.0.1"
-
-	// Commit Hash is the shortened git commit of the clientmount daemon. This value is patched
-	// if using the "build-daemon" make target, and "unknown" otherwise.
-	commitHash = "unknown"
+	// This is a version tag.  If there are commits past that tag, then
+	// a count is appended with a short git hash of the latest commit.
+	version = "v0.0.0"
 )
 
-func BuildVersion() string { return version + "-" + commitHash }
+func BuildVersion() string { return version }


### PR DESCRIPTION
Give the compute daemon a version id similar to the one use for the container image, and let the daemon report its version when requested.