### PR TITLE
Change mount daemon name to clientmountd

### DIFF
--- a/mount-daemon/main.go
+++ b/mount-daemon/main.go
@@ -50,7 +50,7 @@ import (
 )
 
 const (
-	name        = "clientmount"
+	name        = "clientmountd"
 	description = "Data Workflow Service (DWS) Client Mount Service"
 )
 


### PR DESCRIPTION
The Makefile target build-daemon builds an executable called `clientmountd` and the specfile also installs it to /usr/bin/clientmountd. When doing an install of the daemon, the service file created is called `clientmount.service` rather than `clientmountd.service`.

Changing the name here allows for consistency, which is necessary for nnf-deploy to use the dws Makefile to build the daemon rather than building itself. With the change to using the Makefile, nnf-deploy will then look for a service named `clientmountd` rather than `clientmount`.